### PR TITLE
feat: change rewards to treasury ops

### DIFF
--- a/interfaces/badger/IController.sol
+++ b/interfaces/badger/IController.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.5.0 <0.8.0;
+
+interface IController {
+    function withdraw(address, uint256) external;
+
+    function withdrawAll(address) external;
+
+    function strategies(address) external view returns (address);
+
+    function approvedStrategies(address, address) external view returns (address);
+
+    function balanceOf(address) external view returns (uint256);
+
+    function earn(address, uint256) external;
+
+    function approveStrategy(address, address) external;
+
+    function setStrategy(address, address) external;
+
+    function setVault(address, address) external;
+
+    function setRewards(address) external;
+
+    function want(address) external view returns (address);
+
+    function strategist() external view returns (address);
+
+    function governance() external view returns (address);
+
+    function rewards() external view returns (address);
+
+    function vaults(address) external view returns (address);
+}

--- a/interfaces/badger/IStrategy.sol
+++ b/interfaces/badger/IStrategy.sol
@@ -18,6 +18,10 @@ interface IStrategy {
 
     function balanceOf() external view returns (uint256);
 
+    function performanceFeeStrategist() external view returns (uint256);
+
+    function performanceFeeGovernance() external view returns (uint256);
+
     function getName() external pure returns (string memory);
 
     function setStrategist(address _strategist) external;

--- a/scripts/issue/57/set_rewards_to_treasury_ops.py
+++ b/scripts/issue/57/set_rewards_to_treasury_ops.py
@@ -1,0 +1,77 @@
+from brownie import interface
+from eth_abi import encode_abi
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import registry
+from rich.console import Console
+
+C = Console()
+
+TREASURY_OPS = registry.eth.badger_wallets.treasury_ops_multisig
+DEV_PROXY = registry.eth.badger_wallets.devProxyAdmin
+
+# Excluding the recovered and mStable controllers purpously
+# as their rewards are meant to go to other destinations.
+CONTROLLER_IDS = [
+    "native",
+    "harvest",
+    "experimental",
+    "bbveCVX-CVX-f",
+    "ibBTCCrv",
+]
+
+
+def main(queue="true"):
+    """
+    Context: As long as the strategist performance fee is set to 0, all performance
+    fees go to the controller.rewards() for each strategy's controller. Withdrawal
+    fees always go to this address.
+
+    Loops through all controllers and calls setRewards(treasury_ops_multisig) on them.
+    Some controllers are governed by the Timelock so this call must be queued.
+    Additionally, loops through all strategies and ensures that all of them have their
+    performanceFeeStrategist set to 0.
+    """
+
+    safe = GreatApeSafe(registry.eth.badger_wallets.dev_multisig)
+    safe.init_badger()
+
+    # Verify that strategist performance fee is 0 for all strats (Except stablecoin strats)
+    for key, address in (registry.eth.strategies).items():
+        strat = interface.IStrategy(address)
+        if strat.performanceFeeStrategist() != 0:
+            C.print(f"[red]performanceFeeStrategist not 0 for {key}[red]")
+
+    for controller_id in CONTROLLER_IDS:
+        controller = interface.IController(registry.eth.controllers[controller_id])
+        if controller.rewards() != TREASURY_OPS:
+            if controller.governance() == safe.address:
+                controller.setRewards(TREASURY_OPS, {"from": safe.address})
+                assert controller.rewards() == TREASURY_OPS
+                C.print(f"[green]Rewards set to TreasuryOps on {controller_id}[green]")
+            elif controller.governance() == registry.eth.governance_timelock:
+                if queue == "true":
+                    safe.badger.queue_timelock(
+                        target_addr=controller.address,
+                        signature="setRewards(address)",
+                        data=encode_abi(
+                            ["address"],
+                            [TREASURY_OPS],
+                        ),
+                        dump_dir="data/badger/timelock/set_rewards_to_treasury_ops/",
+                        delay_in_days=4,
+                    )
+                    C.print(f"[green]Rewards set to TreasuryOps on {controller_id} was queued![green]")
+                else:
+                    safe.badger.execute_timelock("data/badger/timelock/set_rewards_to_treasury_ops/")
+                    assert controller.rewards() == TREASURY_OPS
+                    C.print(f"[green]Rewards set to TreasuryOps on {controller_id}[green]")
+            else:
+                C.print(
+                    f"[red]Governance is not the devMulti nor the Timelock for {controller_id}![red]"
+                )
+        else:
+            C.print(f"[green]Rewards already set to TreasuryOps on {controller_id}[green]")
+
+
+    safe.post_safe_tx()
+    


### PR DESCRIPTION
This PR closes issue #57 

As long as the strategist performance fee is set to 0, all performance fees go to the controller.rewards() for each strategy's controller. Withdrawal fees always go to this address.

Script that loops through all controllers and calls setRewards(treasury_ops_multisig) on them. Some controllers are governed by the Timelock so this call must be queued. Additionally, loops through all strategies and reports if any doesn't have its performanceFeeStrategist set to 0.

Note: The restitution controller and mStable controller were left out on purpose. Both of these have different fee processing structure.

Run the following to queue:
```
brownie run scripts/issue/57/set_rewards_to_treasury_ops.py
```
And to execute:
```
brownie run scripts/issue/57/set_rewards_to_treasury_ops.py main false
```