### PR TITLE
feat: approve contract access on ibbtc peaks

### DIFF
--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -375,6 +375,7 @@ ADDRESSES_ETH = {
 ADDRESSES_IBBTC = {
     "zero": "0x0000000000000000000000000000000000000000",
     "badger_multisig": ADDRESSES_ETH["badger_wallets"]["dev_multisig"],
+    "dfdBadgerShared": ADDRESSES_ETH["badger_wallets"]["dfdBadgerShared"],
     "defiDollar_fees": "0x5b5cf8620292249669e1dcc73b753d01543d6ac7",
     "feesink": "0x3b823864cd0cbad8a1f2b65d4807906775becaa7",
     "core": ADDRESSES_ETH["ibBTC"]["core"],

--- a/interfaces/defidollar/ICore.sol
+++ b/interfaces/defidollar/ICore.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.0;
+
+interface ICore {
+    function mint(
+        uint256 btc,
+        address account,
+        bytes32[] calldata merkleProof
+    ) external returns (uint256);
+
+    function redeem(uint256 btc, address account) external returns (uint256);
+
+    function btcToBbtc(uint256 btc) external view returns (uint256, uint256);
+
+    function bBtcToBtc(uint256 bBtc) external view returns (uint256 btc, uint256 fee);
+
+    function pricePerShare() external view returns (uint256);
+
+    function setGuestList(address guestlist) external;
+
+    function collectFee() external;
+
+    function owner() external view returns (address);
+
+    function feeSink() external view returns (address);
+
+    function mintFee() external view returns (uint256);
+
+    function redeemFee() external view returns (uint256);
+
+    function accumulatedFee() external view returns (uint256);
+
+    function guestList() external view returns (address);
+
+    function bBTC() external view returns (address);
+
+    function peaks(address) external view returns (uint256);
+
+    function guardian() external view returns (address);
+
+    function setGuardian(address) external;
+
+    function paused() external view returns (bool);
+
+    function unpause() external;
+
+    function pause() external;
+}

--- a/interfaces/defidollar/IPeak.sol
+++ b/interfaces/defidollar/IPeak.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.11;
+
+interface IPeak {
+    function mint(
+        uint256 poolId,
+        uint256 inAmount,
+        bytes32[] calldata merkleProof
+    ) external returns (uint256);
+
+    function approveContractAccess(address account) external;
+
+    function approved(address) external view returns (bool);
+
+    function redeem(uint256 poolId, uint256 inAmount) external returns (uint256);
+
+    function portfolioValue() external view returns (uint256);
+
+    function core() external view returns (address);
+
+    function numPools() external view returns (uint256);
+
+    function owner() external view returns (address);
+
+    function byvWBTC() external view returns (address);
+
+    function pools(uint256) external view returns (address);
+
+    function guardian() external view returns (address);
+
+    function setGuardian(address) external;
+
+    function paused() external view returns (bool);
+}

--- a/interfaces/defidollar/IZap.sol
+++ b/interfaces/defidollar/IZap.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.11;
+
+interface IZap {
+    function mint(address token, uint amount, uint poolId, uint idx, uint minOut)
+        external
+        returns(uint _ibbtc);
+
+    function redeem(address token, uint amount, uint poolId, int128 idx, uint minOut)
+        external
+        returns(uint out);
+}

--- a/scripts/issue/78/grant_access_ibbtc_peak.py
+++ b/scripts/issue/78/grant_access_ibbtc_peak.py
@@ -4,16 +4,17 @@ from brownie import interface
 
 TREASURY_OPS = registry.eth.badger_wallets.treasury_ops_multisig
 
-def main():
+def main(peak="badger"):
     safe = GreatApeSafe(registry.ibbtc.dfdBadgerShared)
     safe.init_badger()
 
-    badger_peak = interface.IPeak(registry.ibbtc.badgerPeak, owner=safe.account)
-    byvWbtc_peak = interface.IPeak(registry.ibbtc.byvWbtcPeak, owner=safe.account)
-
-    badger_peak.approveContractAccess(TREASURY_OPS)
-    assert badger_peak.approved(TREASURY_OPS)
-    byvWbtc_peak.approveContractAccess(TREASURY_OPS)
-    assert byvWbtc_peak.approved(TREASURY_OPS)
+    if peak == "badger":
+        badger_peak = interface.IPeak(registry.ibbtc.badgerPeak, owner=safe.account)
+        badger_peak.approveContractAccess(TREASURY_OPS)
+        assert badger_peak.approved(TREASURY_OPS)
+    else:
+        byvWbtc_peak = interface.IPeak(registry.ibbtc.byvWbtcPeak, owner=safe.account)
+        byvWbtc_peak.approveContractAccess(TREASURY_OPS)
+        assert byvWbtc_peak.approved(TREASURY_OPS)
 
     safe.post_safe_tx()

--- a/scripts/issue/78/grant_access_ibbtc_peak.py
+++ b/scripts/issue/78/grant_access_ibbtc_peak.py
@@ -1,0 +1,19 @@
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import registry
+from brownie import interface
+
+TREASURY_OPS = registry.eth.badger_wallets.treasury_ops_multisig
+
+def main():
+    safe = GreatApeSafe(registry.ibbtc.dfdBadgerShared)
+    safe.init_badger()
+
+    badger_peak = interface.IPeak(registry.ibbtc.badgerPeak, owner=safe.account)
+    byvWbtc_peak = interface.IPeak(registry.ibbtc.byvWbtcPeak, owner=safe.account)
+
+    badger_peak.approveContractAccess(TREASURY_OPS)
+    assert badger_peak.approved(TREASURY_OPS)
+    byvWbtc_peak.approveContractAccess(TREASURY_OPS)
+    assert byvWbtc_peak.approved(TREASURY_OPS)
+
+    safe.post_safe_tx()

--- a/scripts/issue/78/grant_access_ibbtc_peak.py
+++ b/scripts/issue/78/grant_access_ibbtc_peak.py
@@ -6,7 +6,6 @@ TREASURY_OPS = registry.eth.badger_wallets.treasury_ops_multisig
 
 def main(peak="badger"):
     safe = GreatApeSafe(registry.ibbtc.dfdBadgerShared)
-    safe.init_badger()
 
     if peak == "badger":
         badger_peak = interface.IPeak(registry.ibbtc.badgerPeak, owner=safe.account)


### PR DESCRIPTION
This PR closes issue #78 

Grants contract access to the treasury_ops multi on both ibBTC peaks. The peaks are owned by the DefiDollar-Badger dual multi, so the txs are to be loaded there.

**NOTE:**The atomic tx had to be split as there was an `ExecutionFailure` when running the two together - couldn't figure out the reason. Txs go through when loaded independently. 

Run the following to approve on the Badger peak;
```
brownie run scripts/issue/78/grant_access_ibbtc_peak.py
```

And with the following to approve on the byvWBTC peak;
```
brownie run scripts/issue/78/grant_access_ibbtc_peak.py main byvwbtc
```