### PR TITLE
feat: set rewards payload data

### DIFF
--- a/data/badger/timelock/set_rewards_to_treasury_ops/0x33dac5d2618088df29e2de3eee3e809441ecab7705feb2ccad263fdbabab100a.json
+++ b/data/badger/timelock/set_rewards_to_treasury_ops/0x33dac5d2618088df29e2de3eee3e809441ecab7705feb2ccad263fdbabab100a.json
@@ -1,0 +1,7 @@
+{
+    "data": "000000000000000000000000042b32ac6b453485e357938bdc38e0340d4b9276",
+    "eta": 1644232652,
+    "eth": 0,
+    "signature": "setRewards(address)",
+    "target": "0x9b4efA18c0c6b4822225b81D150f3518160f8609"
+}

--- a/data/badger/timelock/set_rewards_to_treasury_ops/0xca0d48afce71bfaa44ff1a46910a24ced38e729da0a905eb0d9136722f6c34ef.json
+++ b/data/badger/timelock/set_rewards_to_treasury_ops/0xca0d48afce71bfaa44ff1a46910a24ced38e729da0a905eb0d9136722f6c34ef.json
@@ -1,0 +1,7 @@
+{
+    "data": "000000000000000000000000042b32ac6b453485e357938bdc38e0340d4b9276",
+    "eta": 1644232650,
+    "eth": 0,
+    "signature": "setRewards(address)",
+    "target": "0x63cF44B2548e4493Fd099222A1eC79F3344D9682"
+}

--- a/data/badger/timelock/set_rewards_to_treasury_ops/0xdac70473101f62ff5de46a0678120ce9065d65d483b126e04db4cdd9e4411b7b.json
+++ b/data/badger/timelock/set_rewards_to_treasury_ops/0xdac70473101f62ff5de46a0678120ce9065d65d483b126e04db4cdd9e4411b7b.json
@@ -1,0 +1,7 @@
+{
+    "data": "000000000000000000000000042b32ac6b453485e357938bdc38e0340d4b9276",
+    "eta": 1644232651,
+    "eth": 0,
+    "signature": "setRewards(address)",
+    "target": "0x30392694C25fbBE5C026CF846e9b6525A2aC3eC8"
+}

--- a/scripts/issue/57/set_rewards_to_treasury_ops.py
+++ b/scripts/issue/57/set_rewards_to_treasury_ops.py
@@ -58,7 +58,7 @@ def main(queue="true"):
                             [TREASURY_OPS],
                         ),
                         dump_dir="data/badger/timelock/set_rewards_to_treasury_ops/",
-                        delay_in_days=4,
+                        delay_in_days=4.7,
                     )
                     C.print(f"[green]Rewards set to TreasuryOps on {controller_id} was queued![green]")
                 else:


### PR DESCRIPTION
This PR relates to issue #57 

Adds the payload data from the rewards address change on the controllers governed by the Timelock.