### PR TITLE
feat: script to consolidate badger

### DIFF
--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -15,6 +15,7 @@ ADDRESSES_ETH = {
     "guardian": "0x6615e67b8B6b6375D38A0A3f937cd8c1a1e96386",
     "GatedMiniMeController": "0xdDB2dfad74F64F14bb1A1cbaB9C03bc0eed74493",
     "GlobalAccessControl": "0x9c58B0D88578cd75154Bdb7C8B013f7157bae35a",
+    "badger_geyser": "0xBD9c69654B8F3E5978DFd138B00cB0Be29F28cCf",
     # the wallets listed here are looped over by scout and checked for all treasury tokens
     "badger_wallets": {
         "fees": "0x8dE82C4C968663a0284b01069DDE6EF231D0Ef9B",
@@ -68,6 +69,7 @@ ADDRESSES_ETH = {
         "devUngatedProxyAdmin": "0x9215cBDCDe25629d0e3D69ee5562d1b444Cf69F9",
         "testProxyAdmin": "0xB10b3Af646Afadd9C62D663dd5d226B15C25CdFA",
         "techOpsProxyAdmin": "0x7D0398D7D7432c47Dffc942Cd097B9eA3d88C385",
+        "opsProxyAdmin_old": "0x4599F2913a3db4E73aA77A304cCC21516dd7270D",
         "badgerHunt": "0x394DCfbCf25C5400fcC147EbD9970eD34A474543",
         "rewardsEscrow": "0xBE838aE7f6Ba97e7Eb545a3f43eE96FfBb3184DC",
     },
@@ -263,6 +265,7 @@ ADDRESSES_ETH = {
         "SettV1h": "0x9376B47E7eC9D4cfd5313Dc1FB0DFF4F61E8c481",
         "SettV1_1h": "0x25c9BD2eE36ef38992f8a6BE4CadDA9442Bf4170",
         "SettV4h": "0x0B7Cb84bc7ad4aF3E1C5312987B6E9A4612068AD",
+        "SimpleTimelockWithVoting": "0xb7AcD34643181C879437c2967538D5c0eA42b5D9", # V1.1 -> Beneficiary: devMulti
     },
     "guestlists": {
         "bimBTC": "0x7feCCc72aE222e0483cBDE212F5F88De62132546",

--- a/interfaces/aragon/IAgent.sol
+++ b/interfaces/aragon/IAgent.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.5.0 <0.8.0;
+
+interface IAgent {
+    function transfer(address _token, address _to, uint256 _value) external;
+}

--- a/interfaces/aragon/IVoting.sol
+++ b/interfaces/aragon/IVoting.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.5.0 <0.8.0;
+
+interface IVoting {
+    function vote(
+        uint256 _voteId,
+        bool _supports,
+        bool _executesIfDecided
+    ) external payable;
+}

--- a/interfaces/badger/IBalanceChecker.sol
+++ b/interfaces/badger/IBalanceChecker.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0;
+
+// Generic address whitelist.
+interface IBalanceChecker {
+    // Checks if address exists in whitelist.
+    function verifyBalance(address token, address account, uint256 amount) external returns (bool);
+}

--- a/interfaces/badger/IProxyAdmin.sol
+++ b/interfaces/badger/IProxyAdmin.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.5.0 <0.8.0;
+
+interface IProxyAdmin {
+    function upgrade(address proxy, address implementation) external;
+
+    function changeProxyAdmin(address proxy, address newAdmin) external;
+
+    function owner() external view returns (address);
+}

--- a/interfaces/badger/ISimpleTimelockWithVoting.sol
+++ b/interfaces/badger/ISimpleTimelockWithVoting.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.5.0 <0.8.0;
+
+interface ISimpleTimelockWithVoting {
+    function beneficiary() external view returns (address);
+
+    function token() external view returns (address);
+
+    function releaseTime() external view returns (uint256);
+
+    function setBeneficiary(address beneficiary) external returns (address);
+    
+    function release() external;
+}

--- a/scripts/issue/71/consolidate_badger.py
+++ b/scripts/issue/71/consolidate_badger.py
@@ -45,8 +45,8 @@ def main(upgrade="true", simulation="false"):
         # Beneficiary is currently the DAO_Agent
         assert dao_treasury.beneficiary() == registry.eth.badger_wallets.fees
 
-        # Nonces are messed up on this multi - next in line is 78
-        old_multi.post_safe_tx(replace_nonce=78)
+        # Nonces are messed up on this multi - replace 76 (on-chain rejection)
+        old_multi.post_safe_tx(replace_nonce=76)
 
     else:
         # Simulates upgrade of contract
@@ -115,28 +115,27 @@ def main(upgrade="true", simulation="false"):
         balance_checker.verifyBalance(
             badger_token.address,
             BADGER_GEYSER,
-            geyser_deficit
+            geyser_deficit + geyser_balance
         )
 
         # Once the Geyser has enough BADGER within, we can
         # withdrawAll to transfer all BADGER from strat to the vault
-        assert bBadger_vault.available() == 0
-
         controller.withdrawAll(bBadger_vault.token())
 
-        assert bBadger_vault.available() == strategy_balanceOf
+        assert bBadger_vault.available() >= strategy_balanceOf
         assert bBadger_strat.balanceOf() == 0
         assert badger_token.balanceOf(BADGER_GEYSER) == 0
 
         # Transfer remaining of amount received from the DAO_treasury to
         # the treaury vault multisig
         amount = treasury_balance - geyser_deficit
+        treasury_vault_balance = badger_token.balanceOf(TREASURY_VAULT)
         badger_token.transfer(TREASURY_VAULT, amount, {"from": safe.address})
 
         balance_checker.verifyBalance(
             badger_token.address,
             TREASURY_VAULT,
-            amount
+            amount + treasury_vault_balance
         )
 
         safe.print_snapshot()

--- a/scripts/issue/71/consolidate_badger.py
+++ b/scripts/issue/71/consolidate_badger.py
@@ -1,0 +1,145 @@
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import registry
+from brownie import interface
+from rich.console import Console
+
+CONSOLE = Console()
+
+DEV_MULTISIG = registry.eth.badger_wallets.dev_multisig
+OLD_OPS_MULTISIG = registry.eth.badger_wallets.ops_multisig_old
+TREASURY_VAULT = registry.eth.badger_wallets.treasury_vault_multisig
+
+BADGER_GEYSER = registry.eth.badger_geyser
+
+def main(upgrade="true", simulation="false"):
+    badger_token = interface.IBadger(registry.eth.treasury_tokens.BADGER)
+
+    old_multi = GreatApeSafe(OLD_OPS_MULTISIG)
+
+    old_devProxyAdmin = interface.IProxyAdmin(
+        registry.eth.badger_wallets.opsProxyAdmin_old,
+        owner=old_multi.account
+    )
+    dao_treasury = interface.ISimpleTimelockWithVoting(
+        registry.eth.badger_wallets.DAO_treasury,
+        owner=old_multi.account
+    )
+
+    if upgrade == "true":
+        ## == Upgrade DAO_Treasury to new logic from the opsMultisig_old == ##
+
+        # Save storage variabls for later
+        treasury_balance = badger_token.balanceOf(dao_treasury.address)
+        token = dao_treasury.token()
+        releaseTime = dao_treasury.releaseTime()
+        beneficiary = dao_treasury.beneficiary()
+        
+        # Upgrades logic and verifies storage
+        new_logic = registry.eth.logic.SimpleTimelockWithVoting
+        old_devProxyAdmin.upgrade(dao_treasury.address, new_logic)
+
+        assert treasury_balance == badger_token.balanceOf(dao_treasury.address)
+        assert token == dao_treasury.token()
+        assert releaseTime == dao_treasury.releaseTime()
+        assert beneficiary == dao_treasury.beneficiary()
+        # Beneficiary is currently the DAO_Agent
+        assert dao_treasury.beneficiary() == registry.eth.badger_wallets.fees
+
+        # Nonces are messed up on this multi - next in line is 78
+        old_multi.post_safe_tx(replace_nonce=78)
+
+    else:
+        # Simulates upgrade of contract
+        if simulation == "true":
+            new_logic = registry.eth.logic.SimpleTimelockWithVoting
+            old_devProxyAdmin.upgrade(dao_treasury.address, new_logic)
+
+        safe = GreatApeSafe(DEV_MULTISIG)
+        treasury_vault = GreatApeSafe(TREASURY_VAULT)
+        safe.take_snapshot(tokens=[registry.eth.treasury_tokens.BADGER])
+        treasury_vault.take_snapshot(tokens=[registry.eth.treasury_tokens.BADGER])
+
+        # Contracts needed
+        controller = interface.IController(
+            registry.eth.controllers.native,
+            owner=safe.account
+        )
+        balance_checker = interface.IBalanceChecker(
+            registry.eth.helpers.balance_checker,
+            owner=safe.account
+        )
+        dao_treasury = interface.ISimpleTimelockWithVoting(
+            registry.eth.badger_wallets.DAO_treasury,
+            owner=safe.account
+        )
+        bBadger_vault = interface.ISettV4h(
+            registry.eth.sett_vaults.bBADGER,
+            owner=safe.account
+        )
+        bBadger_strat = interface.IStrategy(
+            registry.eth.strategies["native.badger"],
+            owner=safe.account
+        )
+
+        ## == Release all BADGER from DAO_Treasury to devMulti == ##
+        
+        # Sets new beneficiary
+        dao_treasury.setBeneficiary(DEV_MULTISIG)
+        assert dao_treasury.beneficiary() == DEV_MULTISIG
+
+        treasury_balance = badger_token.balanceOf(dao_treasury.address)
+        gov_balance = badger_token.balanceOf(DEV_MULTISIG)
+
+        # Release BADGER to devMultisig
+        dao_treasury.release()
+
+        balance_checker.verifyBalance(
+            badger_token.address,
+            DEV_MULTISIG,
+            treasury_balance + gov_balance
+        )
+
+        ## == Transfer missing BADGER to Geyser and withdrawAll to vault == ##
+        geyser_balance = badger_token.balanceOf(BADGER_GEYSER)
+        strategy_balanceOf = bBadger_strat.balanceOf()
+        geyser_deficit = strategy_balanceOf - geyser_balance
+
+        # Ensure geyser is in deficit
+        assert geyser_deficit > 0
+        
+        # Transfer missing BADGER to Geyser
+        badger_token.transfer(BADGER_GEYSER, geyser_deficit, {"from": safe.address})
+
+        CONSOLE.print(f"{geyser_deficit / 1e18} BADGERs were transfer to the Geyser!\n")
+
+        balance_checker.verifyBalance(
+            badger_token.address,
+            BADGER_GEYSER,
+            geyser_deficit
+        )
+
+        # Once the Geyser has enough BADGER within, we can
+        # withdrawAll to transfer all BADGER from strat to the vault
+        assert bBadger_vault.available() == 0
+
+        controller.withdrawAll(bBadger_vault.token())
+
+        assert bBadger_vault.available() == strategy_balanceOf
+        assert bBadger_strat.balanceOf() == 0
+        assert badger_token.balanceOf(BADGER_GEYSER) == 0
+
+        # Transfer remaining of amount received from the DAO_treasury to
+        # the treaury vault multisig
+        amount = treasury_balance - geyser_deficit
+        badger_token.transfer(TREASURY_VAULT, amount, {"from": safe.address})
+
+        balance_checker.verifyBalance(
+            badger_token.address,
+            TREASURY_VAULT,
+            amount
+        )
+
+        safe.print_snapshot()
+        treasury_vault.print_snapshot()
+
+        safe.post_safe_tx(post=(simulation != "true"))


### PR DESCRIPTION
This PR tackles issue #71 

The script is split into two parts:

### PART 1: Upgrade DAO_treasury contract
- Upgrades the logic of the DAO_treasury contract to the newly deployed logic which changes the beneficiary of the release() function.
- Upgrade performed on the old_proxyAdmin directly from the the [Ops_Multisig_old](https://gnosis-safe.io/app/eth:0x576cD258835C529B54722F84Bb7d4170aA932C64/transactions/queue).

Run Part 1 with:
```
brownie run scripts/issue/71/consolidate_badger.py main false true
```

### PART 2: Releases BADGER and redirects
- Releases all the BADGER from the DAO_treasury into the devMulti
- Checks for the deficit between the bBADGER strat staked balance and the Geyser balance and fills out the Geyser to this amount
- Calls `controller.withdrawAll(BADGER)` to move all BADGER from the strat to the vault (Reverts unless there is enough balance on the Geyser to withdraw, hence the previous step).
- Transfer the remaining amount of BADGER obtained from the DAO_treasury  into the Treasury Vault multi.

All of the above is performed atomically for better security.

You can simulate the upgrade of the DAO_treasury and the execution of PART 2 with the following:
```
brownie run scripts/issue/71/consolidate_badger.py main false true
```
Run Part 2 with:
```
brownie run scripts/issue/71/consolidate_badger.py main false
```

**NOTE:** PART 1 must execute in order to be able to load PART 2.