### PR TITLE
some more automation in the bribe claiming process

### DIFF
--- a/great_ape_safe/ape_api/badger.py
+++ b/great_ape_safe/ape_api/badger.py
@@ -133,7 +133,8 @@ class Badger():
             )
             if claimable > 0:
                 claimables.append(token_addr)
-        self.strat_bvecvx.claimBribesFromConvex(claimables)
+        if len(claimables) > 0:
+            self.strat_bvecvx.claimBribesFromConvex(claimables)
 
 
     def queue_timelock(self, target_addr, signature, data, dump_dir, delay_in_days=2.3):

--- a/great_ape_safe/ape_api/badger.py
+++ b/great_ape_safe/ape_api/badger.py
@@ -3,6 +3,7 @@ import os
 import requests
 
 from brownie import chain, interface
+from brownie.exceptions import VirtualMachineError
 from eth_abi import encode_abi
 
 from helpers.addresses import registry
@@ -80,14 +81,35 @@ class Badger():
         """
         # this does not leverage the `claimMulti` func yet but just loops
         for symbol, token_addr in eligible_claims.items():
+            print(symbol)
             directory = 'data/Votium/merkle/'
-            last_json = sorted(os.listdir(directory + symbol))[-1]
+            try:
+                last_json = sorted(os.listdir(directory + symbol))[-1]
+            except FileNotFoundError:
+                # given token is not a votium reward
+                continue
             with open(directory + symbol + f'/{last_json}') as f:
                 try:
                     leaf = json.load(f)['claims'][self.strat_bvecvx.address]
                 except KeyError:
                     # no claimables for the strat for this particular token
                     continue
+                try:
+                    self.strat_bvecvx.claimBribeFromVotium.call(
+                        token_addr,
+                        leaf['index'],
+                        self.strat_bvecvx.address,
+                        leaf['amount'],
+                        leaf['proof']
+                    )
+                except VirtualMachineError as e:
+                    if str(e) == 'revert: Drop already claimed.':
+                        continue
+                    if str(e) == 'revert: SafeERC20: low-level call failed':
+                        # $ldo claim throws this on .call, dont know why
+                        pass
+                    else:
+                        raise
                 self.strat_bvecvx.claimBribeFromVotium(
                     token_addr,
                     leaf['index'],

--- a/great_ape_safe/ape_api/cow.py
+++ b/great_ape_safe/ape_api/cow.py
@@ -13,7 +13,7 @@ from helpers.addresses import registry
 class Cow():
     """
     docs: https://docs.cow.fi/
-    explorer: https://gnosis-protocol.io/
+    explorer: https://explorer.cow.fi/
     api reference: https://api.cow.fi/docs/
     """
 
@@ -42,7 +42,7 @@ class Cow():
 
 
     def _sell(self, sell_token, mantissa_sell, buy_token,
-        mantissa_buy, deadline):
+        mantissa_buy, deadline, coef=1):
         """call api to get sell quote and post order"""
 
         # make sure mantissa is an integer
@@ -71,7 +71,7 @@ class Cow():
             assert type(mantissa_buy) == int
             buy_amount_after_fee = mantissa_buy
         else:
-            buy_amount_after_fee = int(r.json()['buyAmountAfterFee'])
+            buy_amount_after_fee = int(int(r.json()['buyAmountAfterFee']) * coef)
         assert fee_amount > 0
         assert buy_amount_after_fee > 0
 
@@ -136,7 +136,7 @@ class Cow():
             sys.exit()
 
 
-    def market_sell(self, asset_sell, asset_buy, mantissa_sell, deadline=60*60, chunks=1):
+    def market_sell(self, asset_sell, asset_buy, mantissa_sell, deadline=60*60, chunks=1, coef=1):
         """
         wrapper for _sell method;
         mantissa_sell is exact and order is submitted at quoted rate
@@ -151,7 +151,8 @@ class Cow():
                 asset_buy,
                 mantissa_buy=None,
                 # without + n api will raise DuplicateOrder when chunks > 1
-                deadline=deadline + n
+                deadline=deadline + n,
+                coef=coef
             )
 
 

--- a/scripts/badger/claim_bribes.py
+++ b/scripts/badger/claim_bribes.py
@@ -1,0 +1,17 @@
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import registry
+
+
+def main():
+    safe = GreatApeSafe(registry.eth.badger_wallets.techops_multisig)
+    safe.init_badger()
+
+    bribes_dest = GreatApeSafe(safe.badger.strat_bvecvx.BRIBES_RECEIVER())
+    bribes_dest.take_snapshot(registry.eth.bribe_tokens_claimable.values())
+
+    safe.badger.claim_bribes_votium(registry.eth.bribe_tokens_claimable)
+    safe.badger.claim_bribes_convex(registry.eth.bribe_tokens_claimable)
+
+    bribes_dest.print_snapshot()
+
+    safe.post_safe_tx(call_trace=True)

--- a/scripts/badger/swap_bribes_for_bvecvx.py
+++ b/scripts/badger/swap_bribes_for_bvecvx.py
@@ -3,7 +3,7 @@ swap_bribes_for_bvecvx.py: sell all collected convex and votium bribes for
 $bvecvx.
 """
 
-from brownie import ETH_ADDRESS, interface
+from brownie import Contract, interface
 
 from great_ape_safe import GreatApeSafe
 from helpers.addresses import registry
@@ -16,13 +16,16 @@ BVECVX = interface.ISettV4h(
 )
 TREE = GreatApeSafe(registry.eth.badger_wallets.badgertree)
 TECHOPS = GreatApeSafe(registry.eth.badger_wallets.techops_multisig)
+TROPS = GreatApeSafe(registry.eth.badger_wallets.treasury_ops_multisig)
 
 WANT_TO_SELL = registry.eth.bribe_tokens_claimable.copy()
 WANT_TO_SELL.pop('CVX') # SameBuyAndSellToken
+WANT_TO_SELL.pop('T') # UnsupportedToken
+
+# not enough volume to make gas for swap worth it
 WANT_TO_SELL.pop('SPELL')
 WANT_TO_SELL.pop('MTA')
 WANT_TO_SELL.pop('NSBT')
-WANT_TO_SELL.pop('T') # UnsupportedToken
 
 
 def multi_approve():
@@ -46,14 +49,14 @@ def multi_sell():
     SAFE.post_safe_tx()
 
 
-def limit_sell_spell(cvxspell_rate):
+def multi_sell_cheap(coef=.99):
     SAFE.init_cow()
-    spell = interface.ERC20(
-        registry.eth.bribe_tokens_claimable.SPELL, owner=SAFE.account
-    )
-    SAFE.cow.limit_sell(
-        spell, CVX, spell.balanceOf(SAFE), cvxspell_rate * 1e18, deadline=60*60*12
-    )
+    for _, addr in WANT_TO_SELL.items():
+        token = SAFE.contract(addr)
+        if token.balanceOf(SAFE) > 0:
+            SAFE.cow.market_sell(
+                token, CVX, token.balanceOf(SAFE), deadline=60*60*4, coef=coef
+            )
     SAFE.post_safe_tx()
 
 
@@ -66,27 +69,33 @@ def swap_bvecvxcvxf_pool():
     SAFE.post_safe_tx()
 
 
-def lock_cvx():
-    TECHOPS.take_snapshot(tokens=[CVX.address, BVECVX.address])
+def lock_cvx(perf_perc=.1575):
+    SAFE.take_snapshot(tokens=[CVX.address, BVECVX.address])
     TREE.take_snapshot(tokens=[CVX.address, BVECVX.address])
+    TROPS.take_snapshot(tokens=[CVX.address, BVECVX.address])
 
-    CVX.approve(BVECVX, CVX.balanceOf(TECHOPS), {'from': TECHOPS.address})
-    BVECVX.depositFor(TREE, CVX.balanceOf(TECHOPS), {'from': TECHOPS.address})
+    CVX.approve(BVECVX, CVX.balanceOf(SAFE))
+    total = CVX.balanceOf(SAFE)
+    perf_fee = int(total * perf_perc)
+    emissions = total - perf_fee
+    BVECVX.depositFor(TROPS, perf_fee)
+    BVECVX.depositFor(TREE, emissions)
 
+    TROPS.print_snapshot()
     TREE.print_snapshot()
-    TECHOPS.print_snapshot()
+    SAFE.print_snapshot()
 
-    TECHOPS.post_safe_tx()
+    SAFE.post_safe_tx()
 
 
 def sell_t_on_curve():
     t = interface.ERC20(
         registry.eth.bribe_tokens_claimable.T, owner=SAFE.account
     )
-    t_v2_pool = interface.ICurvePoolV2(
+    t_v2_pool = Contract(
         registry.eth.crv_factory_pools.t_eth_f, owner=SAFE.account
     )
-    cvx_v2_pool = interface.ICurvePoolV2(
+    cvx_v2_pool = Contract(
         registry.eth.crv_factory_pools.cvx_eth_f, owner=SAFE.account
     )
     SAFE.init_curve_v2()

--- a/scripts/badger/swap_bribes_for_bvecvx.py
+++ b/scripts/badger/swap_bribes_for_bvecvx.py
@@ -35,7 +35,7 @@ def multi_approve():
         if token.balanceOf(SAFE) > 0:
             print(_, token.balanceOf(SAFE))
             token.approve(SAFE.cow.vault_relayer, token.balanceOf(SAFE))
-    SAFE.post_safe_tx(call_trace=True, replace_nonce=18)
+    SAFE.post_safe_tx(call_trace=True)
 
 
 def multi_sell():


### PR DESCRIPTION
- added more `try/except`s to make things easier
- cowswap func now has feature to sell at x% of quoted market price
- script is now so generalised it can be run every round, as long as we keep `data/Votium/merkle/` updated through `git pull` and add new bribe tokens to `registry.eth.bribe_tokens_claimable`