### PR TITLE
redirect and redeem outstanding dropt3 rewards to treasury ops

### DIFF
--- a/scripts/issue/217/claim_dropt.py
+++ b/scripts/issue/217/claim_dropt.py
@@ -11,16 +11,21 @@ def main():
     safe = GreatApeSafe(registry.eth.badger_wallets.treasury_ops_multisig)
     safe.init_badger()
 
+    # reward tokens
     digg = registry.eth.treasury_tokens.DIGG
+    bcvxCRV = registry.eth.treasury_tokens.bcvxCRV
+    bveCVX = registry.eth.treasury_tokens.bveCVX
+
     bdigg = interface.ISettV4h(registry.eth.treasury_tokens.bDIGG, owner=safe.address)
     dropt = safe.contract(registry.eth.uma.DIGG_LongShortPair)
     dropt_long = safe.contract(dropt.longToken())
 
-
     safe.take_snapshot(tokens=[
         bdigg.address,
         digg,
-        dropt_long
+        dropt_long,
+        bcvxCRV,
+        bveCVX,
     ])
 
     safe.badger.claim_all()
@@ -28,7 +33,7 @@ def main():
     dropt_long_bal = dropt_long.balanceOf(safe)
     # redeem dropt-3 for bdigg
     dropt.settle(dropt_long_bal, 0)
-    
+
     bdigg.withdrawAll()
 
     safe.print_snapshot()

--- a/scripts/issue/217/claim_dropt.py
+++ b/scripts/issue/217/claim_dropt.py
@@ -28,7 +28,7 @@ def main():
     dropt_long_bal = dropt_long.balanceOf(safe)
     # redeem dropt-3 for bdigg
     dropt.settle(dropt_long_bal, 0)
-
+    
     bdigg.withdrawAll()
 
     safe.print_snapshot()

--- a/scripts/issue/217/claim_dropt.py
+++ b/scripts/issue/217/claim_dropt.py
@@ -29,6 +29,7 @@ def main():
     ])
 
     safe.badger.claim_all()
+    assert dropt_long.balanceOf(safe.badger.tree) == 0
 
     dropt_long_bal = dropt_long.balanceOf(safe)
     # redeem dropt-3 for bdigg

--- a/scripts/issue/217/issue217.py
+++ b/scripts/issue/217/issue217.py
@@ -1,0 +1,35 @@
+from brownie import interface
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import registry
+
+
+def main():
+    """
+    claim dropt-3 from tree and redeem for bdigg -> digg
+    """
+
+    safe = GreatApeSafe(registry.eth.badger_wallets.treasury_ops_multisig)
+    safe.init_badger()
+
+    digg = registry.eth.treasury_tokens.DIGG
+    bdigg = interface.ISettV4h(registry.eth.treasury_tokens.bDIGG, owner=safe.address)
+    dropt = safe.contract(registry.eth.uma.DIGG_LongShortPair)
+    dropt_long = safe.contract(dropt.longToken())
+
+
+    safe.take_snapshot(tokens=[
+        bdigg.address,
+        digg,
+        dropt_long
+    ])
+
+    safe.badger.claim_all()
+
+    dropt_long_bal = dropt_long.balanceOf(safe)
+    # redeem dropt-3 for bdigg
+    dropt.settle(dropt_long_bal, 0)
+
+    bdigg.withdrawAll()
+
+    safe.print_snapshot()
+    safe.post_safe_tx()


### PR DESCRIPTION
**solves #217**:  add script to claim tree reward from trops and redeem for bdigg and withdraw to digg(?)
run:
`brownie run issue/217/claim_dropt.py`