### PR TITLE
Script to add keys to registry from console

### DIFF
--- a/great_ape_safe/ape_api/badger.py
+++ b/great_ape_safe/ape_api/badger.py
@@ -5,6 +5,7 @@ import requests
 from brownie import chain, interface
 from brownie.exceptions import VirtualMachineError
 from eth_abi import encode_abi
+from helpers.constants import AddressZero
 
 from helpers.addresses import registry
 from rich.console import Console
@@ -254,3 +255,15 @@ class Badger():
         controller.approveStrategy(want, strat_addr)
         controller.setStrategy(want, strat_addr)
         assert controller.strategies(want) == strat_addr
+
+
+    def set_key_on_registry(self, registry_addr, key, target_addr):
+        registry = interface.IBadgerRegistry(registry_addr, owner=self.safe.account)
+        
+        # Ensures key doesn't currently exist
+        assert registry.get(key) == AddressZero
+
+        registry.set(key, target_addr)
+
+        assert registry.get(key) == target_addr
+        C.print(f'{key} was added to the registry at {target_addr}')

--- a/great_ape_safe/ape_api/badger.py
+++ b/great_ape_safe/ape_api/badger.py
@@ -1,11 +1,12 @@
 import json
 import os
 import requests
+import brownie
 
 from brownie import chain, interface
 from brownie.exceptions import VirtualMachineError
 from eth_abi import encode_abi
-from helpers.constants import AddressZero
+# from helpers.constants import AddressZero
 
 from helpers.addresses import registry
 from rich.console import Console
@@ -41,6 +42,11 @@ class Badger():
         )
         self.timelock = safe.contract(
             registry.eth.governance_timelock
+        )
+
+        self.registry = interface.IBadgerRegistry(
+            registry.eth.registry,
+            owner=self.safe.account
         )
 
         # misc
@@ -257,13 +263,11 @@ class Badger():
         assert controller.strategies(want) == strat_addr
 
 
-    def set_key_on_registry(self, registry_addr, key, target_addr):
-        registry = interface.IBadgerRegistry(registry_addr, owner=self.safe.account)
-        
+    def set_key_on_registry(self, key, target_addr):
         # Ensures key doesn't currently exist
-        assert registry.get(key) == AddressZero
+        assert self.registry.get(key) == brownie.ZERO_ADDRESS
 
-        registry.set(key, target_addr)
+        self.registry.set(key, target_addr)
 
-        assert registry.get(key) == target_addr
+        assert self.registry.get(key) == target_addr
         C.print(f'{key} was added to the registry at {target_addr}')

--- a/interfaces/badger/IBadgerRegistry.sol
+++ b/interfaces/badger/IBadgerRegistry.sol
@@ -7,4 +7,6 @@ interface IBadgerRegistry {
   function get(string calldata name) external view returns (address);
 
   function set(string memory key, address at) external;
+
+  event Set(string key, address at);
 }

--- a/interfaces/badger/IBadgerRegistry.sol
+++ b/interfaces/badger/IBadgerRegistry.sol
@@ -4,9 +4,82 @@ pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 interface IBadgerRegistry {
-  function get(string calldata name) external view returns (address);
+    event AddKey(string key);
+    event AddVersion(string version);
+    event DemoteVault(
+        address author,
+        string version,
+        address vault,
+        uint8 status
+    );
+    event NewVault(address author, string version, address vault);
+    event PromoteVault(
+        address author,
+        string version,
+        address vault,
+        uint8 status
+    );
+    event RemoveVault(address author, string version, address vault);
+    event Set(string key, address at);
 
-  function set(string memory key, address at) external;
+    function add(string memory version, address vault) external;
 
-  event Set(string key, address at);
+    function addVersions(string memory version) external;
+
+    function addresses(string memory) external view returns (address);
+
+    function demote(
+        string memory version,
+        address vault,
+        uint8 status
+    ) external;
+
+    function devGovernance() external view returns (address);
+
+    function get(string memory key) external view returns (address);
+
+    function getFilteredProductionVaults(string memory version, uint8 status)
+        external
+        view
+        returns (address[] memory);
+
+    function getProductionVaults()
+        external
+        view
+        returns (BadgerRegistry.VaultData[] memory);
+
+    function getVaults(string memory version, address author)
+        external
+        view
+        returns (address[] memory);
+
+    function governance() external view returns (address);
+
+    function initialize(address newGovernance) external;
+
+    function keys(uint256) external view returns (string memory);
+
+    function promote(
+        string memory version,
+        address vault,
+        uint8 status
+    ) external;
+
+    function remove(string memory version, address vault) external;
+
+    function set(string memory key, address at) external;
+
+    function setDev(address newDev) external;
+
+    function setGovernance(address _newGov) external;
+
+    function versions(uint256) external view returns (string memory);
+}
+
+interface BadgerRegistry {
+    struct VaultData {
+        string version;
+        uint8 status;
+        address[] list;
+    }
 }

--- a/interfaces/badger/IBadgerRegistry.sol
+++ b/interfaces/badger/IBadgerRegistry.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+interface IBadgerRegistry {
+  function get(string calldata name) external view returns (address);
+
+  function set(string memory key, address at) external;
+}

--- a/scripts/badger/registry.py
+++ b/scripts/badger/registry.py
@@ -1,0 +1,21 @@
+from brownie import web3
+from rich.console import Console
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import registry
+
+
+console = Console()
+
+# assuming techOps
+SAFE = GreatApeSafe(registry.eth.badger_wallets.techops_multisig)
+SAFE.init_badger()
+REGISTRY = registry.eth.registry
+
+
+def set_key(key, target_addr):
+    """
+    Sets the input target address on the registry under the specified 'key' 
+    """
+
+    SAFE.badger.set_key_on_registry(REGISTRY, key, target_addr)
+    SAFE.post_safe_tx()

--- a/scripts/badger/registry.py
+++ b/scripts/badger/registry.py
@@ -9,13 +9,11 @@ console = Console()
 # assuming techOps
 SAFE = GreatApeSafe(registry.eth.badger_wallets.techops_multisig)
 SAFE.init_badger()
-REGISTRY = registry.eth.registry
-
 
 def set_key(key, target_addr):
     """
     Sets the input target address on the registry under the specified 'key' 
     """
 
-    SAFE.badger.set_key_on_registry(REGISTRY, key, target_addr)
+    SAFE.badger.set_key_on_registry(key, target_addr)
     SAFE.post_safe_tx()


### PR DESCRIPTION
This PR sill be used totackle issue #229 

Adds a function to the Badger API to set keys on the registry as well as a general script to interact with this function directly from the console. Use the following to run:

```
brownie run scripts/badger/registry.py set_key KEY Target_Address
```

For example:
```
brownie run scripts/badger/registry.py set_key GAC 0x9c58B0D88578cd75154Bdb7C8B013f7157bae35a
```