### PR TITLE
make cvx bribe functions conform to bip87

### DIFF
--- a/great_ape_safe/ape_api/cow.py
+++ b/great_ape_safe/ape_api/cow.py
@@ -42,8 +42,11 @@ class Cow():
 
 
     def _sell(self, sell_token, mantissa_sell, buy_token,
-        mantissa_buy, deadline, coef=1):
+        mantissa_buy, deadline, coef, destination):
         """call api to get sell quote and post order"""
+
+        # set destination to self if not specified
+        destination = self.safe.address if not destination else destination
 
         # make sure mantissa is an integer
         assert type(mantissa_sell) == int
@@ -82,7 +85,7 @@ class Cow():
         order_payload = {
             'sellToken': sell_token.address,
             'buyToken': buy_token.address,
-            'receiver': self.safe.address,
+            'receiver': destination,
             'sellAmount': str(mantissa_sell - fee_amount),
             'buyAmount': str(buy_amount_after_fee),
             'validTo': deadline,
@@ -136,7 +139,7 @@ class Cow():
             sys.exit()
 
 
-    def market_sell(self, asset_sell, asset_buy, mantissa_sell, deadline=60*60, chunks=1, coef=1):
+    def market_sell(self, asset_sell, asset_buy, mantissa_sell, deadline=60*60, chunks=1, coef=1, destination=None):
         """
         wrapper for _sell method;
         mantissa_sell is exact and order is submitted at quoted rate
@@ -152,11 +155,12 @@ class Cow():
                 mantissa_buy=None,
                 # without + n api will raise DuplicateOrder when chunks > 1
                 deadline=deadline + n,
-                coef=coef
+                coef=coef,
+                destination=destination
             )
 
 
-    def limit_sell(self, asset_sell, asset_buy, mantissa_sell, mantissa_buy, deadline=60*60, chunks=1):
+    def limit_sell(self, asset_sell, asset_buy, mantissa_sell, mantissa_buy, deadline=60*60, chunks=1, destination=None):
         """
         wrapper for _sell method;
         both the sell and buy mantissas are exact, resulting in a limit order
@@ -172,7 +176,9 @@ class Cow():
                 asset_buy,
                 mantissa_buy,
                 # without + n api will raise DuplicateOrder when chunks > 1
-                deadline + n
+                deadline=deadline + n,
+                coef=1,
+                destination=destination
             )
 
 

--- a/scripts/badger/swap_bribes_for_bvecvx.py
+++ b/scripts/badger/swap_bribes_for_bvecvx.py
@@ -75,10 +75,10 @@ def swap_for_cvx_and_badger():
     SAFE.init_cow()
     SAFE.cow.allow_relayer(WETH, WETH.balanceOf(SAFE))
     SAFE.cow.market_sell(
-        WETH, BADGER, badger_share, deadline=60*60, coef=.98,
+        WETH, BADGER, badger_share, deadline=60*60, coef=.985,
         destination=TREE.address
     )
-    SAFE.cow.market_sell(WETH, CVX, cvx_share, deadline=60*60, coef=.98)
+    SAFE.cow.market_sell(WETH, CVX, cvx_share, deadline=60*60, coef=.985)
     SAFE.post_safe_tx()
 
 

--- a/scripts/badger/swap_bribes_for_bvecvx.py
+++ b/scripts/badger/swap_bribes_for_bvecvx.py
@@ -1,6 +1,6 @@
 """
 swap_bribes_for_bvecvx.py: sell all collected convex and votium bribes for
-$bvecvx.
+$bvecvx and $badger---as per bip87.
 """
 
 from brownie import Contract, interface
@@ -14,9 +14,14 @@ CVX = SAFE.contract(registry.eth.treasury_tokens.CVX)
 BVECVX = interface.ISettV4h(
     registry.eth.treasury_tokens.bveCVX, owner=SAFE.account
 )
+WETH = interface.IWETH9(registry.eth.treasury_tokens.WETH, owner=SAFE.account)
+BADGER = interface.ERC20(
+    registry.eth.treasury_tokens.BADGER, owner=SAFE.account
+)
 TREE = GreatApeSafe(registry.eth.badger_wallets.badgertree)
 TECHOPS = GreatApeSafe(registry.eth.badger_wallets.techops_multisig)
 VAULT = GreatApeSafe(registry.eth.badger_wallets.treasury_vault_multisig)
+VOTING_SAFE = GreatApeSafe(registry.eth.badger_wallets.bvecvx_voting_multisig)
 
 WANT_TO_SELL = registry.eth.bribe_tokens_claimable.copy()
 WANT_TO_SELL.pop('CVX') # SameBuyAndSellToken
@@ -25,13 +30,18 @@ WANT_TO_SELL.pop('CVX') # SameBuyAndSellToken
 WANT_TO_SELL.pop('MTA')
 WANT_TO_SELL.pop('NSBT')
 
+# percentage of the bribes that is used to buyback $badger
+BADGER_SHARE = .275
+# percentage of the bribes that are dedicated to the treasury
+OPS_FEE = .05
+
 
 def multi_approve():
     SAFE.init_cow()
-    for _, addr in WANT_TO_SELL.items():
+    for symbol, addr in WANT_TO_SELL.items():
         token = SAFE.contract(addr)
         if token.balanceOf(SAFE) > 0:
-            print(_, token.balanceOf(SAFE))
+            print(symbol, token.balanceOf(SAFE))
             token.approve(SAFE.cow.vault_relayer, token.balanceOf(SAFE))
     SAFE.post_safe_tx(call_trace=True)
 
@@ -47,14 +57,28 @@ def multi_sell():
     SAFE.post_safe_tx()
 
 
-def multi_sell_cheap(coef=.98):
+def multi_sell_cheap(coef=.985):
     SAFE.init_cow()
     for _, addr in WANT_TO_SELL.items():
         token = SAFE.contract(addr)
         if token.balanceOf(SAFE) > 0:
             SAFE.cow.market_sell(
-                token, CVX, token.balanceOf(SAFE), deadline=60*60*4, coef=coef
+                token, WETH, token.balanceOf(SAFE), deadline=60*60, coef=coef
             )
+    SAFE.post_safe_tx()
+
+
+def swap_for_cvx_and_badger():
+    badger_share = int(WETH.balanceOf(SAFE) * BADGER_SHARE)
+    cvx_share = WETH.balanceOf(SAFE) - badger_share
+    assert badger_share + cvx_share == WETH.balanceOf(SAFE)
+    SAFE.init_cow()
+    SAFE.cow.allow_relayer(WETH, WETH.balanceOf(SAFE))
+    SAFE.cow.market_sell(
+        WETH, BADGER, badger_share, deadline=60*60, coef=.98,
+        destination=TREE.address
+    )
+    SAFE.cow.market_sell(WETH, CVX, cvx_share, deadline=60*60, coef=.98)
     SAFE.post_safe_tx()
 
 
@@ -67,19 +91,20 @@ def swap_bvecvxcvxf_pool():
     SAFE.post_safe_tx()
 
 
-def lock_cvx(perf_perc=.1575):
+def lock_cvx():
     SAFE.take_snapshot(tokens=[CVX.address, BVECVX.address])
     TREE.take_snapshot(tokens=[CVX.address, BVECVX.address])
-    VAULT.take_snapshot(tokens=[CVX.address, BVECVX.address])
+    VOTING_SAFE.take_snapshot(tokens=[CVX.address, BVECVX.address])
 
     CVX.approve(BVECVX, CVX.balanceOf(SAFE))
     total = CVX.balanceOf(SAFE)
-    perf_fee = int(total * float(perf_perc))
-    emissions = total - perf_fee
-    BVECVX.depositFor(VAULT, perf_fee)
+    ops_fee = int(total / (1 - BADGER_SHARE) * OPS_FEE)
+    emissions = total - ops_fee
+    assert emissions + ops_fee == CVX.balanceOf(SAFE)
+    BVECVX.depositFor(VOTING_SAFE, ops_fee)
     BVECVX.depositFor(TREE, emissions)
 
-    VAULT.print_snapshot()
+    VOTING_SAFE.print_snapshot()
     TREE.print_snapshot()
     SAFE.print_snapshot()
 


### PR DESCRIPTION
this is to help make bribe selling more streamlined until @GalloDaSballo gets his automation of it deployed. steps to take, in this order:
- `multi_approve()` - approves all tokens to the gnosis vault relayer in `WANT_TO_SELL`
- `multi_sell_cheap()` - sell all bribes for $weth. max default slippage now at 1.5%, this seems to be max we encountered within a time window of 1 hour.
- `swap_for_cvx_and_badger()` - first run will approve all $weth to gnosis vault relayer. once approved, second run will swap part of the $weth for $badger (destination being the tree) and swap the other part of $weth for $cvx.
- `lock_cvx()` - lock the $cvx; part goes to the treasury and part goes to the tree