### PR TITLE
Script to Upgrade BadgerSettPeak and Sweep bveCVX

### DIFF
--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -283,6 +283,7 @@ ADDRESSES_ETH = {
         "SettV1_1h": "0x25c9BD2eE36ef38992f8a6BE4CadDA9442Bf4170",
         "SettV4h": "0x0B7Cb84bc7ad4aF3E1C5312987B6E9A4612068AD",
         "SimpleTimelockWithVoting": "0xb7AcD34643181C879437c2967538D5c0eA42b5D9", # V1.1 -> Beneficiary: devMulti
+        "BadgerSettPeak": "0x56bb91BfbeEB5400db72bcE4c15eb0Ddfd06002C", # V1.1
     },
     "guestlists": {
         "bimBTC": "0x7feCCc72aE222e0483cBDE212F5F88De62132546",

--- a/interfaces/defidollar/IPeak.sol
+++ b/interfaces/defidollar/IPeak.sol
@@ -32,4 +32,6 @@ interface IPeak {
     function setGuardian(address) external;
 
     function paused() external view returns (bool);
+
+    function sweepUnprotectedToken(address _token, address _destination) external;
 }

--- a/interfaces/defidollar/IUpgradableProxy.sol
+++ b/interfaces/defidollar/IUpgradableProxy.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.7.0 <0.9.0;
+
+interface IUpgradableProxy {
+    event OwnershipTransferred(
+        address indexed previousOwner,
+        address indexed newOwner
+    );
+    event ProxyUpdated(address indexed previousImpl, address indexed newImpl);
+
+    fallback() external;
+
+    function implementation() external view returns (address _impl);
+
+    function owner() external view returns (address _owner);
+
+    function proxyType() external pure returns (uint256 proxyTypeId);
+
+    function transferOwnership(address newOwner) external;
+
+    function updateImplementation(address _newProxyTo) external;
+}

--- a/scripts/issue/204/upgrade_peak_and_sweep.py
+++ b/scripts/issue/204/upgrade_peak_and_sweep.py
@@ -8,7 +8,7 @@ SAFE = GreatApeSafe(registry.eth.badger_wallets.dfdBadgerShared)
 NEW_LOGIC = registry.eth.logic["BadgerSettPeak"] 
 PEAK = interface.IPeak(registry.eth.peaks.badgerPeak, owner=SAFE.account)
 BVECVX = interface.ERC20(registry.eth.treasury_tokens.bveCVX)
-TREASURY_VAULT = registry.eth.badger_wallets.treasury_vault_multisig
+BVECVX_VOTING_MULTI = registry.eth.badger_wallets.bvecvx_voting_multisig
 BALANCE_CHECKER = interface.IBalanceChecker(registry.eth.helpers.balance_checker, owner=SAFE.account)
 
 # Atomically upgrades the BadgerSettPeak contract and calls the sweeping function
@@ -39,14 +39,14 @@ def main():
     assert pools == PEAK.pools(0)
 
     # Sweeps stuck bveCVX
-    vault_balance_before = BVECVX.balanceOf(TREASURY_VAULT)
+    vault_balance_before = BVECVX.balanceOf(BVECVX_VOTING_MULTI)
     peak_balance_before = BVECVX.balanceOf(PEAK.address)
 
-    PEAK.sweepUnprotectedToken(BVECVX.address, TREASURY_VAULT)
+    PEAK.sweepUnprotectedToken(BVECVX.address, BVECVX_VOTING_MULTI)
 
     BALANCE_CHECKER.verifyBalance(
         BVECVX.address, 
-        TREASURY_VAULT,
+        BVECVX_VOTING_MULTI,
         vault_balance_before + peak_balance_before
     )
     assert BVECVX.balanceOf(PEAK.address) == 0

--- a/scripts/issue/204/upgrade_peak_and_sweep.py
+++ b/scripts/issue/204/upgrade_peak_and_sweep.py
@@ -1,0 +1,55 @@
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import registry
+from brownie import interface
+import brownie
+
+SAFE = GreatApeSafe(registry.eth.badger_wallets.dfdBadgerShared)
+
+NEW_LOGIC = registry.eth.logic["BadgerSettPeak"] 
+PEAK = interface.IPeak(registry.eth.peaks.badgerPeak, owner=SAFE.account)
+BVECVX = interface.ERC20(registry.eth.treasury_tokens.bveCVX)
+TREASURY_VAULT = registry.eth.badger_wallets.treasury_vault_multisig
+BALANCE_CHECKER = interface.IBalanceChecker(registry.eth.helpers.balance_checker, owner=SAFE.account)
+
+# Atomically upgrades the BadgerSettPeak contract and calls the sweeping function
+# to recover the bveCVX stuck into the treasury vault
+
+def main():
+  
+    # Get all storage variables, we'll use them later
+    portfolioValue = PEAK.portfolioValue()
+    core = PEAK.core()
+    numPools = PEAK.numPools()
+    owner = PEAK.owner()
+    pools = PEAK.pools(0) # Currently only one pool
+
+    # Upgrade logic
+    PEAK_PROXY = interface.IUpgradableProxy(
+        registry.eth.peaks.badgerPeak, 
+        owner=SAFE.account
+    )
+    assert PEAK_PROXY.owner() == SAFE.account
+    PEAK_PROXY.updateImplementation(NEW_LOGIC)
+
+    # Checking all variables are as expected
+    assert portfolioValue == PEAK.portfolioValue()
+    assert core == PEAK.core()
+    assert numPools == PEAK.numPools()
+    assert owner == PEAK.owner()
+    assert pools == PEAK.pools(0)
+
+    # Sweeps stuck bveCVX
+    vault_balance_before = BVECVX.balanceOf(TREASURY_VAULT)
+    peak_balance_before = BVECVX.balanceOf(PEAK.address)
+
+    PEAK.sweepUnprotectedToken(BVECVX.address, TREASURY_VAULT)
+
+    BALANCE_CHECKER.verifyBalance(
+        BVECVX.address, 
+        TREASURY_VAULT,
+        vault_balance_before + peak_balance_before
+    )
+    assert BVECVX.balanceOf(PEAK.address) == 0
+
+
+    SAFE.post_safe_tx()


### PR DESCRIPTION
This PR closes issue #204 

Upgrades the logic of ibBTC's BadgerSettPeak to add a sweep function for unprotected tokens. Sweeps the stuck bveCVX into the Treasury Vault multi.

Use the following to run:
```
brownie run scripts/issue/204/upgrade_peak_and_sweep.py
```