### PR TITLE
spookyswap class, better routing for swapping to oxd

### DIFF
--- a/great_ape_safe/ape_api/pancakeswap_v2.py
+++ b/great_ape_safe/ape_api/pancakeswap_v2.py
@@ -12,3 +12,4 @@ class PancakeswapV2(UniV2):
         self.max_slippage = 0.02
         self.max_weth_unwrap = 0.01
         self.deadline = 60 * 60 * 12
+        self.router_symbol = 'ETH'

--- a/great_ape_safe/ape_api/pancakeswap_v2.py
+++ b/great_ape_safe/ape_api/pancakeswap_v2.py
@@ -4,12 +4,7 @@ from helpers.addresses import registry
 
 class PancakeswapV2(UniV2):
     def __init__(self, safe):
-        self.safe = safe
+        super().__init__(safe)
 
         self.router = safe.contract(registry.bsc.pancakeswap.router_v2)
         self.factory = safe.contract(registry.bsc.pancakeswap.factory_v2)
-
-        self.max_slippage = 0.02
-        self.max_weth_unwrap = 0.01
-        self.deadline = 60 * 60 * 12
-        self.router_symbol = 'ETH'

--- a/great_ape_safe/ape_api/solidly.py
+++ b/great_ape_safe/ape_api/solidly.py
@@ -4,12 +4,10 @@ from helpers.addresses import registry
 
 class Solidly(UniV2):
     def __init__(self, safe):
-        self.safe = safe
+        super().__init__(safe)
 
         self.router = safe.contract(registry.ftm.solidly.router)
         self.factory = safe.contract(self.router.factory())
 
         self.max_slippage = 0.05
-        self.max_weth_unwrap = 0.01
-        self.deadline = 60 * 60 * 12
         self.router_symbol = 'FTM'

--- a/great_ape_safe/ape_api/spookyswap.py
+++ b/great_ape_safe/ape_api/spookyswap.py
@@ -4,12 +4,9 @@ from helpers.addresses import registry
 
 class SpookySwap(UniV2):
     def __init__(self, safe):
-        self.safe = safe
+        super().__init__(safe)
 
         self.router = safe.contract(registry.ftm.spookyswap.router)
         self.factory = safe.contract(registry.ftm.spookyswap.factory)
 
         self.max_slippage = 0.05
-        self.max_weth_unwrap = 0.01
-        self.deadline = 60 * 60 * 12
-        self.router_symbol = 'ETH'

--- a/great_ape_safe/ape_api/spookyswap.py
+++ b/great_ape_safe/ape_api/spookyswap.py
@@ -2,14 +2,14 @@ from great_ape_safe.ape_api.uni_v2 import UniV2
 from helpers.addresses import registry
 
 
-class Solidly(UniV2):
+class SpookySwap(UniV2):
     def __init__(self, safe):
         self.safe = safe
 
-        self.router = safe.contract(registry.ftm.solidly.router)
-        self.factory = safe.contract(self.router.factory())
+        self.router = safe.contract(registry.ftm.spookyswap.router)
+        self.factory = safe.contract(registry.ftm.spookyswap.factory)
 
         self.max_slippage = 0.05
         self.max_weth_unwrap = 0.01
         self.deadline = 60 * 60 * 12
-        self.router_symbol = 'FTM'
+        self.router_symbol = 'ETH'

--- a/great_ape_safe/ape_api/sushi.py
+++ b/great_ape_safe/ape_api/sushi.py
@@ -13,3 +13,4 @@ class Sushi(UniV2):
         self.max_slippage = 0.02
         self.max_weth_unwrap = 0.01
         self.deadline = 60 * 60 * 12
+        self.router_symbol = 'ETH'

--- a/great_ape_safe/ape_api/sushi.py
+++ b/great_ape_safe/ape_api/sushi.py
@@ -5,12 +5,7 @@ from helpers.addresses import registry
 
 class Sushi(UniV2):
     def __init__(self, safe):
-        self.safe = safe
+        super().__init__(safe)
 
         self.router = safe.contract(registry.eth.sushiswap.routerV2)
         self.factory = safe.contract(registry.eth.sushiswap.factoryV2)
-
-        self.max_slippage = 0.02
-        self.max_weth_unwrap = 0.01
-        self.deadline = 60 * 60 * 12
-        self.router_symbol = 'ETH'

--- a/great_ape_safe/ape_api/uni_v2.py
+++ b/great_ape_safe/ape_api/uni_v2.py
@@ -1,4 +1,4 @@
-from brownie import accounts, interface, web3
+from brownie import accounts, interface, web3, network
 from helpers.addresses import registry
 from sympy import Symbol
 from sympy.solvers import solve
@@ -7,8 +7,10 @@ class UniV2:
     def __init__(self, safe):
         self.safe = safe
 
-        self.router = safe.contract(registry.eth.uniswap.routerV2)
-        self.factory = safe.contract(registry.eth.uniswap.factoryV2)
+        # handles init called from univ2 child class on different chain
+        if network.chain.id == 1:
+            self.router = safe.contract(registry.eth.uniswap.routerV2)
+            self.factory = safe.contract(registry.eth.uniswap.factoryV2)
 
         self.max_slippage = 0.02
         self.max_weth_unwrap = 0.01

--- a/great_ape_safe/ape_api/uni_v2.py
+++ b/great_ape_safe/ape_api/uni_v2.py
@@ -13,7 +13,7 @@ class UniV2:
         self.max_slippage = 0.02
         self.max_weth_unwrap = 0.01
         self.deadline = 60 * 60 * 12
-        self.native_symbol = 'ETH'
+        self.router_symbol = 'ETH'
 
         
     def get_lp_to_withdraw_given_token(self, lp_token, underlying_token, mantissa_underlying):
@@ -27,7 +27,7 @@ class UniV2:
 
 
     def build_path(self, amountIn, path):
-        pair_info = self.router.getAmountOut(amountIn, path[0], path[-1])
+        pair_info = self.router.getAmountOut(amountIn, path[0].address, path[-1].address)
 
         # if return type is subclass of tuple then its a solidly style router
         if isinstance(pair_info, tuple):
@@ -175,7 +175,7 @@ class UniV2:
         address to,
         uint256 deadline
         """
-        signature = getattr(self.router, f'swapExact{self.native_symbol}ForTokens')
+        signature = getattr(self.router, f'swapExact{self.router_symbol}ForTokens')
         signature(
             amountOut * (1 - self.max_slippage),
             path,
@@ -201,7 +201,7 @@ class UniV2:
         amountOut = self.router.getAmountsOut(amountIn, path)[-1]
         tokenIn.approve(self.router, amountIn)
 
-        signature = getattr(self.router, f'swapExactTokensFor{self.native_symbol}')
+        signature = getattr(self.router, f'swapExactTokensFor{self.router_symbol}')
         signature(
             amountIn,
             amountOut * (1 - self.max_slippage),

--- a/great_ape_safe/great_ape_safe.py
+++ b/great_ape_safe/great_ape_safe.py
@@ -7,7 +7,7 @@ from io import StringIO
 
 import pandas as pd
 from ape_safe import ApeSafe
-from brownie import Contract, network, ETH_ADDRESS
+from brownie import Contract, network, ETH_ADDRESS, exceptions
 from rich.console import Console
 from rich.pretty import pprint
 from tqdm import tqdm
@@ -25,6 +25,7 @@ from great_ape_safe.ape_api.opolis import Opolis
 from great_ape_safe.ape_api.pancakeswap_v2 import PancakeswapV2
 from great_ape_safe.ape_api.rari import Rari
 from great_ape_safe.ape_api.solidly import Solidly
+from great_ape_safe.ape_api.spookyswap import SpookySwap
 from great_ape_safe.ape_api.sushi import Sushi
 from great_ape_safe.ape_api.uni_v2 import UniV2
 from great_ape_safe.ape_api.uni_v3 import UniV3
@@ -51,21 +52,13 @@ class GreatApeSafe(ApeSafe):
 
 
     def init_all(self):
-        self.init_aave()
-        self.init_anyswap()
-        self.init_badger()
-        self.init_compound()
-        self.init_convex()
-        self.init_cow()
-        self.init_curve()
-        self.init_curve_v2()
-        self.init_opolis()
-        self.init_pancakeswap_v2()
-        self.init_rari()
-        self.init_solidly()
-        self.init_sushi()
-        self.init_uni_v2()
-        self.init_uni_v3()
+        for method in self.__dir__():
+            if method.startswith('init_') and method != 'init_all':
+                try:
+                    getattr(self, method)()
+                except exceptions.ContractNotFound:
+                    # different chain
+                    pass
 
 
     def init_aave(self):
@@ -118,6 +111,10 @@ class GreatApeSafe(ApeSafe):
 
     def init_solidly(self):
         self.solidly = Solidly(self)
+
+
+    def init_spookyswap(self):
+        self.spookyswap = SpookySwap(self)
 
 
     def init_sushi(self):

--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -712,6 +712,10 @@ ADDRESSES_FANTOM = {
     "solidly": {
         "router": "0xa38cd27185a464914D3046f0AB9d43356B34829D",
         "factory": "0x3fAaB499b519fdC5819e3D7ed0C26111904cbc28"
+    },
+    "spookyswap": {
+        "router": "0xF491e7B69E4244ad4002BC14e878a34207E38c29",
+        "factory": "0x152eE697f2E276fA89E96742e9bB9aB1F2E61bE3"
     }
 }
 

--- a/scripts/issue/333/swap_dfd_comp_for_oxd.py
+++ b/scripts/issue/333/swap_dfd_comp_for_oxd.py
@@ -85,7 +85,7 @@ def swap_usdc_for_oxd(amount_mantissa=None):
 
     TROPS_FTM.solidly.swap_tokens_for_tokens(
         WFTM,
-        WFTM.balanceOf(TROPS_FTM),
+        WFTM.balanceOf(TROPS_FTM) * 0.98,
         [WFTM, OXD]
         )
 

--- a/scripts/issue/333/swap_dfd_comp_for_oxd.py
+++ b/scripts/issue/333/swap_dfd_comp_for_oxd.py
@@ -74,12 +74,19 @@ def bridge_usdc_to_ftm(mantissa):
 def swap_usdc_for_oxd(amount_mantissa=None):
     # swap for oxd
     TROPS_FTM.init_solidly()
+    TROPS_FTM.init_spookyswap()
     TROPS_FTM.take_snapshot([USDC_FTM, OXD])
 
-    TROPS_FTM.solidly.swap_tokens_for_tokens(
+    TROPS_FTM.spookyswap.swap_tokens_for_tokens(
         USDC_FTM,
-        USDC_FTM.balanceOf(TROPS_FTM) if not amount_mantissa else amount_mantissa,
-        [USDC_FTM, WFTM, OXD]
+        USDC_FTM.balanceOf(TROPS_FTM) if amount_mantissa is None else amount_mantissa,
+        [USDC_FTM, WFTM]
+        )
+
+    TROPS_FTM.solidly.swap_tokens_for_tokens(
+        WFTM,
+        WFTM.balanceOf(TROPS_FTM),
+        [WFTM, OXD]
         )
 
     TROPS_FTM.print_snapshot()


### PR DESCRIPTION
- adds `SpookySwap` class to api.
- `swap_usdc_for_oxd` in #346 now first swaps usdc -> wftm through spooky then swaps wtfm -> oxd through solidly. results in **~22% more oxd**
- revised the ever expanding `GreatApeSafe.init_all`


