### PR TITLE
Add script to update RF, getting failure msg in trace

### DIFF
--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -327,7 +327,7 @@ ADDRESSES_ETH = {
         "fIBBTC-22": "0x6856f0e1BD23c9a1b92f87581Dd2f28E7C84EbcD",
         "fFRAX-22": "0x60fb6aecf861e3f16f7a4dcaddf8d8820244a1cd",
         "fDOLA-22": "0x5117D9453cC9Be8c3fBFbA4aE3B858D18fe45903",
-        "fbveCVX-22": "0x3D9a6A5302a196e3bA41A2374506726e4FE7E14a"
+        "fbveCVX-22": "0x26F6F27fDBc3B9cDe4b1943b1c07606CAF2c4C6C"
     },
     "routers": {
         "sushi_router_v2": "0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F",

--- a/scripts/issue/284/update_rf_rari_pool.py
+++ b/scripts/issue/284/update_rf_rari_pool.py
@@ -22,8 +22,11 @@ def main():
         if key in TARGET_MARKETS:
             # check rf
             current_rf = dev_msig.rari.ftoken_get_rf(value)
-            print(f"Current RF for {key} is {current_rf}, updating it to {TARGET_RF}\n")
-            # update rf
-            dev_msig.rari.ftoken_set_rf(value, TARGET_RF)
+            if current_rf != TARGET_RF:
+                print(f"Current RF for {key} is {current_rf}, updating it to {TARGET_RF}\n")
+                # update rf
+                dev_msig.rari.ftoken_set_rf(value, TARGET_RF)
+            else:
+                print(f"Current RF for {key} is the targetted value\n")
 
     dev_msig.post_safe_tx()

--- a/scripts/issue/284/update_rf_rari_pool.py
+++ b/scripts/issue/284/update_rf_rari_pool.py
@@ -1,0 +1,29 @@
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import registry
+
+TARGET_RF = 0
+TARGET_MARKETS = [
+    "fUSDC-22",
+    "fFEI-22",
+    "fDAI-22",
+    "fFRAX-22",
+    "fDOLA-22",
+    "fWBTC-22",
+    "fETH-22",
+]
+
+
+def main():
+    dev_msig = GreatApeSafe(registry.eth.badger_wallets.dev_multisig)
+
+    dev_msig.init_rari()
+
+    for key, value in registry.eth.rari.items():
+        if key in TARGET_MARKETS:
+            # check rf
+            current_rf = dev_msig.rari.ftoken_get_rf(value)
+            print(f"Current RF for {key} is {current_rf}, updating it to {TARGET_RF}\n")
+            # update rf
+            dev_msig.rari.ftoken_set_rf(value, TARGET_RF)
+
+    dev_msig.post_safe_tx()


### PR DESCRIPTION
Tackles #284, the RF section, which is the pressing params to tweak atm

```
brownie run issue/284/update_rf_rari_pool
```

Converting to draft to digg into the failure err that prompts locally in the trace. Thru sim in Tenderly likely will exec succesfully