### PR TITLE
Fix bveOxd address parameters

### DIFF
--- a/scripts/issue/366/fix_bveoxd_addresses.py
+++ b/scripts/issue/366/fix_bveoxd_addresses.py
@@ -1,0 +1,13 @@
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import registry
+
+
+def main():
+    safe = GreatApeSafe(registry.ftm.badger_wallets.dev_multisig)
+
+    bveoxd = safe.contract(registry.ftm.sett_vaults.bveOXD)
+
+    bveoxd.setTreasury(registry.ftm.badger_wallets.treasury_ops_multisig)
+    bveoxd.setStrategist(registry.ftm.badger_wallets.techops_multisig)
+
+    safe.post_safe_tx()


### PR DESCRIPTION
Addresses #366

I'll transfer the fees earned after this is exec'd. Will post the txs in this thread
```
Events In This Transaction
--------------------------
├── Badger Vested Escrow OXD (0x96d4dBdc91Bef716eb407e415c9987a9fAfb8906)
│   └── SetTreasury
│       └── newTreasury: 0xf109c50684EFa12d4dfBF501eD4858F25A4300B3
│
└── Gnosis Safe (0x4c56ee3295042f8A5dfC83e770a21c707CB46f5b)
    └── ExecutionSuccess
        ├── txHash: 0xa4bf3b62f80a89a629576aa6ec81212736b38d64fb9987e8847a43e202523b7d
        └── payment: 0
```
```
{
│   'ethereum_client': <gnosis.eth.ethereum_client.EthereumClient object at 0x160402e20>,
│   'safe_address': '0x4c56ee3295042f8A5dfC83e770a21c707CB46f5b',
│   'to': '0x10B62CC1E8D9a9f1Ad05BCC491A7984697c19f7E',
│   'value': 0,
│   'data': HexBytes('0x8d80ff0a000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000f20096d4dbdc91bef716eb407e415c9987a9fafb890600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024f0f44260000000000000000000000000f109c50684efa12d4dfbf501ed4858f25a4300b30096d4dbdc91bef716eb407e415c9987a9fafb890600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024c7b9d530000000000000000000000000781e82d5d49042bab750efac91858cb65c6b05820000000000000000000000000000'),
│   'operation': 1,
│   'safe_tx_gas': 0,
│   'base_gas': 0,
│   'gas_price': 0,
│   'gas_token': '0x0000000000000000000000000000000000000000',
│   'refund_receiver': '0x0000000000000000000000000000000000000000',
│   'signatures': b'',
│   '_safe_nonce': 12,
│   '_safe_version': '1.3.0',
│   '_chain_id': None
}
```