### PR TITLE
feat: add AutonomousDripper contract, deploy and tests

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -16,8 +16,10 @@ keys:
 
 dependencies:
     - OpenZeppelin/openzeppelin-contracts@4.5.0
+    - smartcontractkit/chainlink@1.4.0
 
 compiler:
     solc:
         remappings:
           - "@openzeppelin=OpenZeppelin/openzeppelin-contracts@4.5.0"
+          - "@chainlink=smartcontractkit/chainlink@1.4.0"

--- a/contracts/AutonomousDripper.sol
+++ b/contracts/AutonomousDripper.sol
@@ -1,0 +1,137 @@
+// contracts/EmissionsDripper.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/finance/VestingWallet.sol";
+import "@chainlink/contracts/src/v0.8/KeeperCompatible.sol";
+
+/**
+ * @title The AutonomousDripper Contract
+ * @author gosuto.eth
+ * @notice A Chainlink Keeper-compatible version of OpenZeppelin's
+ * VestingWallet; removing the need to monitor the interval and/or call release
+ * manually. Also adds an owner that can sweep all ether and ERC-20 tokens.
+ */
+contract AutonomousDripper is VestingWallet, KeeperCompatibleInterface {
+    event EtherSwept(uint256 amount);
+    event ERC20Swept(address indexed token, uint256 amount);
+
+    address private _owner;
+    uint public lastTimestamp;
+    uint public immutable interval;
+    // TODO: write setter methods that can add or remove entries from this list
+    address[] public assetsWatchlist;
+
+    constructor(
+        address beneficiaryAddress,
+        uint64 startTimestamp,
+        uint64 durationSeconds,
+        address ownerAddress,
+        uint intervalSeconds,
+        address[] memory watchlistAddresses
+    ) VestingWallet(
+        beneficiaryAddress,
+        startTimestamp,
+        durationSeconds
+    ) {
+        _owner = ownerAddress;
+        lastTimestamp = startTimestamp;
+        interval = intervalSeconds;
+        assetsWatchlist = watchlistAddresses;
+    }
+
+    /**
+     * @dev Loop over the assetsWatchlist and check their local balance.
+     * Returns a filtered version of the assetsWatchlist for which the local
+     * balance is greater than zero.
+     * Strongly inspired by https://github.com/smartcontractkit/chainlink/blob/0adf6c0fb256d09e4fed2f2f86a2c027ae82535d/contracts/src/v0.8/upkeeps/EthBalanceMonitor.sol#L87-L116
+     */
+    function _getAssetsHeld() internal view returns (address[] memory) {
+        address[] memory _assetsHeld = new address[](assetsWatchlist.length);
+        uint256 count = 0;
+        for (uint idx = 0; idx < assetsWatchlist.length; idx++) {
+            uint256 balance = IERC20(assetsWatchlist[idx]).balanceOf(address(this));
+            if (balance > 0) {
+                _assetsHeld[count] = assetsWatchlist[idx];
+                count++;
+            }
+        }
+        if (count != assetsWatchlist.length) {
+            assembly {
+                mstore(_assetsHeld, count)
+            }
+        }
+        return _assetsHeld;
+    }
+
+    /**
+     * @dev Runs off-chain at every block to determine if the `performUpkeep`
+     * function should be called on-chain.
+     */
+    function checkUpkeep(bytes calldata) external view override returns (
+        bool upkeepNeeded, bytes memory
+    ) {
+        address[] memory assetsHeld = new address[](assetsWatchlist.length);
+        uint256 count = 0;
+
+        if ((block.timestamp - lastTimestamp) > interval) {
+            assetsHeld = _getAssetsHeld();
+            if (assetsHeld.length > 0) {
+                return (true, abi.encode(assetsHeld));
+            }
+        }
+    }
+
+    /**
+     * @dev Contains the logic that should be executed on-chain when
+     * `checkUpkeep` returns true.
+     */
+    function performUpkeep(bytes calldata performData) external override {
+        if ((block.timestamp - lastTimestamp) > interval) {
+            lastTimestamp = block.timestamp;
+            address[] memory assetsHeld = abi.decode(performData, (address[]));
+            for (uint idx = 0; idx < assetsHeld.length; idx++) {
+                if (IERC20(assetsHeld[idx]).balanceOf(address(this)) > 0) {
+                    VestingWallet.release(assetsHeld[idx]);
+                }
+            }
+        }
+    }
+
+    /**
+     * @dev Getter for the owner address.
+     */
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Setter for the owner address.
+     */
+    function swapOwner(address _newOwner) public {
+        require(_msgSender() == _owner, "AutonomousDripper: onlyOwner");
+        _owner = _newOwner;
+    }
+
+    /**
+     * @dev Sweep the full contract's ether balance to the owner. Can only be
+     * called by the owner.
+     */
+    function sweep() public virtual {
+        require(_msgSender() == _owner, "AutonomousDripper: onlyOwner");
+        uint256 balance = address(this).balance;
+        emit EtherSwept(balance);
+        Address.sendValue(payable(_owner), balance);
+    }
+
+    /**
+     * @dev Sweep the full contract's balance for an ERC20 token to the owner.
+     * Can only be called by the owner.
+     */
+    function sweep(address token) public virtual {
+        require(_msgSender() == _owner, "AutonomousDripper: onlyOwner");
+        uint256 balance = IERC20(token).balanceOf(address(this));
+        emit ERC20Swept(token, balance);
+        SafeERC20.safeTransfer(IERC20(token), _owner, balance);
+    }
+}

--- a/scripts/deployment/deploy_autonomous_dripper.py
+++ b/scripts/deployment/deploy_autonomous_dripper.py
@@ -1,0 +1,40 @@
+from calendar import timegm
+from datetime import date, timedelta
+
+from brownie import AutonomousDripper, accounts, chain
+
+from helpers.addresses import registry
+
+
+def main(deployer_label=None):
+    deployer = accounts[0] if not deployer_label else accounts.load(deployer_label)
+    if chain.id == 1:
+        return AutonomousDripper.deploy(
+            registry.eth.badger_wallets.badgertree,
+            timegm(date(2022, 4, 20).timetuple()),
+            int(timedelta(weeks=9).total_seconds()),
+            deployer,
+            60*60*24*7,
+            [
+                '0x3472A5A71965499acd81997a54BBA8D852C6E53d', # BADGER
+                '0x798D1bE841a82a273720CE31c822C61a67a601C3' # DIGG
+            ],
+            {'from': deployer},
+            # TODO: programmatically set to True when on a non-forked, live network
+            publish_source=False#True
+        )
+    elif chain.id == 4:
+        return AutonomousDripper.deploy(
+            registry.rinkeby.badger_wallets.solo_multisig,
+            timegm(date.today().timetuple()),
+            int(timedelta(weeks=1).total_seconds()),
+            deployer,
+            60*60, # interval of one hour
+            [
+                '0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735', # rinkeby DAI
+                '0x577D296678535e4903D59A4C929B718e1D575e0A' # rinkeby WBTC
+            ],
+            {'from': deployer},
+            # TODO: programmatically set to True when on a non-forked, live network
+            publish_source=True
+        )

--- a/tests/deployment/test_autonomous_dripper.py
+++ b/tests/deployment/test_autonomous_dripper.py
@@ -1,0 +1,116 @@
+from datetime import datetime
+
+import brownie
+import pytest
+from brownie import accounts, chain
+from brownie_tokens import MintableForkToken
+
+from helpers.addresses import registry
+
+
+@pytest.fixture(scope='module')
+def deployer():
+    return accounts[0]
+
+
+@pytest.fixture(scope='module')
+def dripper():
+    from scripts.deployment.deploy_autonomous_dripper import main
+    return main()
+
+
+@pytest.fixture(scope="module")
+def badger():
+    return MintableForkToken(registry.eth.treasury_tokens.BADGER)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def topup_and_fast_forward(dripper, badger):
+    accounts[1].transfer(dripper, 1e18)
+    badger._mint_for_testing(dripper, 100_000 * 10**badger.decimals())
+    assert badger.balanceOf(dripper) > 0
+    now = datetime.now().timestamp()
+    delta = dripper.start() + dripper.interval() - now
+    if delta > 0:
+        # dripping period still has to start, sleep until next block
+        chain.sleep(delta + 1)
+
+
+def test_timestamps(dripper):
+    assert dripper.start() > dripper.duration()
+
+
+def test_duration(dripper):
+    assert dripper.duration() > 0
+    assert dripper.start() + dripper.duration() > datetime.now().timestamp(),\
+        'dripping period already expired; increase start or duration'
+
+
+def test_release_from_owner(badger, dripper):
+    owner = dripper.owner()
+    bal_before = badger.balanceOf(dripper.beneficiary())
+    dripper.release(badger, {'from': owner})
+    assert badger.balanceOf(dripper.beneficiary()) > bal_before
+
+
+def test_accounting_released(dripper, badger):
+    assert dripper.released(badger, {'from': accounts[1]}) > 0
+
+
+def test_release_from_random(badger, dripper):
+    # add some time to build up releasable funds again
+    chain.sleep(60)
+    bal_before = badger.balanceOf(dripper.beneficiary())
+    dripper.release(badger, {'from': accounts[1]})
+    assert badger.balanceOf(dripper.beneficiary()) > bal_before
+
+
+def test_upkeep_needed(dripper, badger):
+    assert chain.time() - dripper.start() > dripper.interval()
+    assert badger.balanceOf(dripper) > 0
+    upkeep_needed, assets_encoded = dripper.checkUpkeep(b'')
+    assert upkeep_needed
+    return upkeep_needed, assets_encoded
+
+
+def test_perform_upkeep(dripper, badger):
+    bal_dripper_before = badger.balanceOf(dripper.beneficiary())
+    bal_benef_before = badger.balanceOf(dripper)
+    upkeep_needed, assets_encoded = test_upkeep_needed(dripper, badger)
+    assert upkeep_needed
+    dripper.performUpkeep(assets_encoded)
+    assert bal_dripper_before > badger.balanceOf(dripper)
+    assert badger.balanceOf(dripper.beneficiary()) > bal_benef_before
+
+
+def test_sweep_eth_from_owner(dripper):
+    owner = accounts.at(dripper.owner())
+    bal_before = owner.balance()
+    dripper.sweep({'from': owner})
+    assert owner.balance() > bal_before
+    assert dripper.balance() == 0
+
+
+def test_sweep_eth_from_random(dripper):
+    with brownie.reverts():
+        dripper.sweep({'from': accounts[1]})
+
+
+def test_sweep_erc_from_owner(dripper, badger):
+    owner = dripper.owner()
+    bal_before = badger.balanceOf(owner)
+    dripper.sweep(badger, {'from': owner})
+    assert badger.balanceOf(owner) > bal_before
+    assert badger.balanceOf(dripper) == 0
+
+
+def test_sweep_erc_from_random(dripper, badger):
+    with brownie.reverts():
+        dripper.sweep(badger, {'from': accounts[1]})
+
+
+def test_upkeep_not_needed(dripper, badger):
+    assert chain.time() - dripper.start() > dripper.interval()
+    assert badger.balanceOf(dripper) == 0
+    upkeep_needed, _ = dripper.checkUpkeep(b'')
+    assert not upkeep_needed

--- a/tests/deployment/test_emissions_dripper.py
+++ b/tests/deployment/test_emissions_dripper.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import brownie
 import pytest
 from brownie import accounts, chain
 from brownie_tokens import MintableForkToken
@@ -75,11 +76,11 @@ def test_release_from_dev(badger, dripper, dev):
     assert badger.balanceOf(dripper.beneficiary()) > bal_before
 
 
-@pytest.mark.xfail
 def test_release_from_random(badger, dripper):
-    bal_before = badger.balanceOf(dripper.beneficiary())
-    dripper.release(badger, {'from': accounts[1]})
-    assert badger.balanceOf(dripper.beneficiary()) > bal_before
+    with brownie.reverts():
+        bal_before = badger.balanceOf(dripper.beneficiary())
+        dripper.release(badger, {'from': accounts[1]})
+        assert badger.balanceOf(dripper.beneficiary()) > bal_before
 
 
 def test_set_keeper_from_dev(dripper, dev):
@@ -90,9 +91,9 @@ def test_set_keeper_from_techops(dripper, techops):
     dripper.setKeeper(accounts[1], {'from': techops.account})
 
 
-@pytest.mark.xfail
 def test_set_keeper_from_random(dripper):
-    dripper.setKeeper(accounts[1], {'from': accounts[1]})
+    with brownie.reverts():
+        dripper.setKeeper(accounts[1], {'from': accounts[1]})
 
 
 def test_sweep_eth_from_dev(dripper, dev):
@@ -102,9 +103,9 @@ def test_sweep_eth_from_dev(dripper, dev):
     assert dripper.balance() == 0
 
 
-@pytest.mark.xfail
 def test_sweep_eth_from_random(dripper):
-    dripper.sweep({'from': accounts[1]})
+    with brownie.reverts():
+        dripper.sweep({'from': accounts[1]})
 
 
 def test_sweep_erc_from_dev(dripper, badger, dev):
@@ -114,6 +115,6 @@ def test_sweep_erc_from_dev(dripper, badger, dev):
     assert badger.balanceOf(dripper) == 0
 
 
-@pytest.mark.xfail
 def test_sweep_erc_from_random(dripper, badger):
-    dripper.sweep(badger, {'from': accounts[1]})
+    with brownie.reverts():
+        dripper.sweep(badger, {'from': accounts[1]})


### PR DESCRIPTION
some changes in regards to previous `EmissionsDripper`:
- no more `keeper` role; the upkeep function needs to be permissionless in order for chainlink keepers to interact with it
- because of this i also removed the `controller` and `governance` roles and replaced them with one single `owner`
- `sweep` remains unchanged (callable by `owner` only)

still need to implement a setter function for the `assetsWatchlist`, which is now only set on deployment