### PR TITLE
Upgrade vestedCVX to V1.7.1

### DIFF
--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -291,7 +291,7 @@ ADDRESSES_ETH = {
         "StrategyCvxHelper": "0x9A12A9141363A5B343B781c4951d42E327B89397", # V1.1
         "StrategyCvxCrvHelper": "0x76328277232c97BAf76D23A69015CB478293A048", # V1.1
         "KeeperAccessControl": "0x4fe70eE8fa906D59A88DE5946F114BdbFC410a80",
-        "native.vestedCVX": "0x57961a757bA249E616c1940548401b7CdF83a849", # V1.7
+        "native.vestedCVX": "0x86ca553D5Ae7cD0005552D6E275786D5043800Bd", # V1.7.1 - Change bribes processor address
         "RewardsRecoveryStrategy_distribution": "0xEDb5a82016c95B0F6099Ec51F463691Fa2ba02B9",
         "SettV1h": "0x9376B47E7eC9D4cfd5313Dc1FB0DFF4F61E8c481",
         "SettV1_1h_V1": "0x25c9BD2eE36ef38992f8a6BE4CadDA9442Bf4170",

--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -20,7 +20,7 @@ ADDRESSES_ETH = {
         "rembadger_2022_q2": "0xD87F434fE6d5B349f4376d2daBA762b213E403c7",
         "tree_2022_q2": "0xfA55d407F48849aE98a6e4f11Dc5C18E035F46Ec",
     },
-    "bribes_processor": "0xbeD8f323456578981952e33bBfbE80D23289246B",
+    "bribes_processor": "0xb2Bf1d48F2C2132913278672e6924efda3385de2",
     # the wallets listed here are looped over by scout and checked for all treasury tokens
     "badger_wallets": {
         "fees": "0x8dE82C4C968663a0284b01069DDE6EF231D0Ef9B",

--- a/scripts/issue/494/upgrade_vestedcvx_strat.py
+++ b/scripts/issue/494/upgrade_vestedcvx_strat.py
@@ -1,0 +1,101 @@
+from eth_abi import encode_abi
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import registry
+from brownie import accounts, interface
+from rich.console import Console
+
+C = Console()
+
+NEW_LOGIC = registry.eth.logic["native.vestedCVX"] 
+DEV_PROXY = registry.eth.badger_wallets.devProxyAdmin
+
+
+def main(queue="true", simulation="false"):
+    safe = GreatApeSafe(registry.eth.badger_wallets.dev_multisig)
+    safe.init_badger()
+
+    strat_proxy = safe.badger.strat_bvecvx
+    bribes_processor = interface.IBribesProcessor(registry.eth.bribes_processor)
+
+    if queue == "true":
+        safe.badger.queue_timelock(
+            target_addr=DEV_PROXY,
+            signature="upgrade(address,address)",
+            data=encode_abi(
+                ["address", "address"],
+                [strat_proxy.address, NEW_LOGIC],
+            ),
+            dump_dir="data/badger/timelock/upgrade_veCVX_strategy_V1_7_1/",
+            delay_in_days=4,
+        )
+    else:   
+        # Setting all variables, we'll use them later
+        prev_strategist = strat_proxy.strategist()
+        prev_gov = strat_proxy.governance()
+        prev_guardian = strat_proxy.guardian()
+        prev_keeper = strat_proxy.keeper()
+        prev_perFeeG = strat_proxy.performanceFeeGovernance()
+        prev_perFeeS = strat_proxy.performanceFeeStrategist()
+        prev_reward = strat_proxy.reward()
+        prev_unit = strat_proxy.uniswap()
+        prev_check_withdrawalSafetyCheck = strat_proxy.withdrawalSafetyCheck()
+        prev_check_harvestOnRebalance = strat_proxy.harvestOnRebalance()
+        prev_check_processLocksOnReinvest = strat_proxy.processLocksOnReinvest()
+        prev_check_processLocksOnRebalance = strat_proxy.processLocksOnRebalance()
+
+        # Constants
+        prev_CVX_EXTRA_SNAPSHOT = strat_proxy.SNAPSHOT()
+        prev_CVX_EXTRA_BADGER_TREE = strat_proxy.BADGER_TREE()
+        prev_DELEGATE = strat_proxy.DELEGATE()
+        prev_DELEGATED_SPACE = strat_proxy.DELEGATED_SPACE()
+        prev_CVXCRV_VAULT = strat_proxy.CVXCRV_VAULT()
+        prev_LOCKER = strat_proxy.LOCKER()
+        prev_CVX_EXTRA_REWARDS = strat_proxy.CVX_EXTRA_REWARDS()
+        prev_CVX_VOTIUM_BRIBE_CLAIMER = strat_proxy.VOTIUM_BRIBE_CLAIMER()
+        prev_CVX_EXTRA_BADGER = strat_proxy.BADGER()
+
+        # Execute upgrade
+        if simulation == "true":
+            C.print("Simulating upgrade...")
+            timelock = accounts.at(registry.eth.governance_timelock, force=True)
+            proxyAdmin = interface.IProxyAdmin(DEV_PROXY, owner=timelock)
+            proxyAdmin.upgrade(strat_proxy.address, NEW_LOGIC)
+        else:
+            safe.badger.execute_timelock("data/badger/timelock/upgrade_veCVX_strategy_V1_7_1/")
+
+        ## Checking all variables are as expected
+        assert prev_strategist == strat_proxy.strategist()
+        assert prev_gov == strat_proxy.governance()
+        assert prev_guardian == strat_proxy.guardian()
+        assert prev_keeper == strat_proxy.keeper()
+        assert prev_perFeeG == strat_proxy.performanceFeeGovernance()
+        assert prev_perFeeS == strat_proxy.performanceFeeStrategist()
+        assert prev_reward == strat_proxy.reward()
+        assert prev_unit == strat_proxy.uniswap()
+        assert prev_check_withdrawalSafetyCheck == strat_proxy.withdrawalSafetyCheck()
+        assert prev_check_harvestOnRebalance == strat_proxy.harvestOnRebalance()
+        assert prev_check_processLocksOnReinvest == strat_proxy.processLocksOnReinvest()
+        assert prev_check_processLocksOnRebalance == strat_proxy.processLocksOnRebalance()
+
+        # Verify constants
+        assert prev_CVX_EXTRA_SNAPSHOT == strat_proxy.SNAPSHOT()
+        assert prev_CVX_EXTRA_BADGER_TREE == strat_proxy.BADGER_TREE()
+        assert prev_DELEGATE == strat_proxy.DELEGATE()
+        assert prev_DELEGATED_SPACE == strat_proxy.DELEGATED_SPACE()
+        assert prev_CVXCRV_VAULT == strat_proxy.CVXCRV_VAULT()
+        assert prev_LOCKER == strat_proxy.LOCKER()
+        assert prev_CVX_EXTRA_REWARDS == strat_proxy.CVX_EXTRA_REWARDS()
+        assert prev_CVX_VOTIUM_BRIBE_CLAIMER == strat_proxy.VOTIUM_BRIBE_CLAIMER()
+        assert prev_CVX_EXTRA_BADGER == strat_proxy.BADGER()
+
+        ## Verify new Addresses are setup properly
+        assert strat_proxy.BRIBES_PROCESSOR() == bribes_processor.address
+
+        # Verify that the bribes_processor's manager points to the correct multisig
+        assert bribes_processor.manager() == registry.eth.badger_wallets.techops_multisig
+
+        # Test chainlink functions
+        if simulation == "true":
+            C.print("[green]Simulation Successful![/green]")
+
+    safe.post_safe_tx(post=(simulation!="true"))


### PR DESCRIPTION
Closes Issue #494

Upgrades vestedCVX to a logic with the new BribesProcessor address hardcoded.

Run queue with:
```
brownie run scripts/issue/494/upgrade_vestedcvx_strat.py
```
Run execution with:
```
brownie run scripts/issue/494/upgrade_vestedcvx_strat.py main false
```
Run simulation with:
```
brownie run scripts/issue/494/upgrade_vestedcvx_strat.py main false true
```