### PR TITLE
update: only exec fee collection if there is any fee to be collected

### DIFF
--- a/great_ape_safe/ape_api/uni_v3.py
+++ b/great_ape_safe/ape_api/uni_v3.py
@@ -111,7 +111,11 @@ class UniV3:
         # https://docs.uniswap.org/protocol/reference/periphery/interfaces/INonfungiblePositionManager#collectparams
         params = (token_id, self.safe.address, self.Q128 - 1, self.Q128 - 1)
 
-        self.nonfungible_position_manager.collect(params)
+        # https://etherscan.io/address/0xC36442b4a4522E871399CD717aBDD847Ab11FE88#code#F1#L314
+        amount0, amount1 = self.nonfungible_position_manager.collect.call(params)
+        
+        if amount0 > 0 or amount1 > 0:
+            self.nonfungible_position_manager.collect(params)
 
     def collect_fees(self):
         """


### PR DESCRIPTION
Tackles #446

Since we [claimed](https://etherscan.io/tx/0x780b8ec118eb57bdef2cfa446f65e08bc83807f7b44d1d4544a90d71a4a2ac92) recently the fees now there may not be any claims available to test it properly. For testing, please leverage the forking at specific block height or locally to explore the values returned in the `.call(params, block_identifier)`. Use block below **14856066**