### PR TITLE
feat: add improved `contract` method

### DIFF
--- a/great_ape_safe/great_ape_safe.py
+++ b/great_ape_safe/great_ape_safe.py
@@ -7,11 +7,12 @@ from io import StringIO
 
 import pandas as pd
 from ape_safe import ApeSafe
-from brownie import Contract, network, ETH_ADDRESS, exceptions
+from brownie import Contract, network, ETH_ADDRESS, exceptions, web3
+from eth_utils import is_address, to_checksum_address
 from rich.console import Console
 from rich.pretty import pprint
 from tqdm import tqdm
-from helpers.chaindata import labels
+from web3.exceptions import BadFunctionCallOutput
 
 from great_ape_safe.ape_api.aave import Aave
 from great_ape_safe.ape_api.anyswap import Anyswap
@@ -30,6 +31,7 @@ from great_ape_safe.ape_api.spookyswap import SpookySwap
 from great_ape_safe.ape_api.sushi import Sushi
 from great_ape_safe.ape_api.uni_v2 import UniV2
 from great_ape_safe.ape_api.uni_v3 import UniV3
+from helpers.chaindata import labels
 
 
 C = Console()
@@ -279,3 +281,24 @@ class GreatApeSafe(ApeSafe):
             safe_tx = self.pending_transactions[0]
         pprint(safe_tx.__dict__)
         self.execute_transaction_with_frame(safe_tx)
+
+
+    def contract(self, address, Interface=None, from_explorer=False):
+        # instantiate a brownie contract, either from an interface, the
+        # explorer or locally saved contract object. if address is somehow
+        # invalid, return None.
+        if is_address(address):
+            address = to_checksum_address(address)
+        else:
+            try:
+                address = web3.ens.resolve(address)
+            except BadFunctionCallOutput:
+                return None
+        if not is_address(address):
+            return None
+        if Interface:
+            return Interface(address, owner=self.account)
+        elif from_explorer:
+            return Contract.from_explorer(address, owner=self.account)
+        else:
+            return Contract(address, owner=self.account)

--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -806,7 +806,7 @@ ADDRESSES_FANTOM = {
         "factory": "0x152eE697f2E276fA89E96742e9bB9aB1F2E61bE3"
     },
     "registry": "0xFda7eB6f8b7a9e9fCFd348042ae675d1d652454f",
-    "registryV2": "0xdc602965F3e5f1e7BAf2446d5564b407d5113A06",
+    "registry_v2": "0xdc602965F3e5f1e7BAf2446d5564b407d5113A06",
 }
 
 
@@ -840,6 +840,7 @@ registry = DotMap({
     "ftm": checksum_address_dict(ADDRESSES_FANTOM),
 })
 
+
 def get_registry():
     if chain.id == 1:
         return registry.eth
@@ -850,7 +851,10 @@ def get_registry():
     elif chain.id == 42161:
         return registry.arbitrum
     elif chain.id == 250:
-        return registry.ftm 
+        return registry.ftm
+
+
+r = get_registry()
 
 # flatten nested dicts and invert the resulting key <-> value
 # this allows for reversed lookup of an address


### PR DESCRIPTION
- new contract method can build `Contract` object from an interface, from explorer or from existing `Contract`.
- in case `address` cannot be resolved to an actual address, the method will just return `None`

if on a chain for which no entry exists in the address book, `r` will just return an empty `DotMap()`. this can then safely be passed to `GreatApeSafe.contract`; it will just return `None`.