### PR TITLE
chore: add minor patch migration + migrate arbitrum registry

### DIFF
--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -563,7 +563,7 @@ ADDRESSES_POLYGON = {
     "badger_wallets": {
         "badgertree": "0x2C798FaFd37C7DCdcAc2498e19432898Bc51376b",
         "rewardLogger": "0xd0EE2A5108b8800D688AbC834445fd03b3b2738e",
-        "ops_multisig": "0xeb7341c89ba46CC7945f75Bd5dD7a04f8FA16327",
+        "techops_multisig": "0xeb7341c89ba46CC7945f75Bd5dD7a04f8FA16327",
         "dev_multisig": "0x4977110Ed3CD5eC5598e88c8965951a47dd4e738",
     },
     "treasury_tokens": {

--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -12,6 +12,7 @@ ADDRESSES_ETH = {
     "rewardsLogger" : "0x0A4F4e92C3334821EbB523324D09E321a6B0d8ec",
     "EmissionControl": "0x31825c0A6278b89338970e3eB979b05B27FAa263",
     "registry": "0xFda7eB6f8b7a9e9fCFd348042ae675d1d652454f",
+    "registry_v2": "0xdc602965F3e5f1e7BAf2446d5564b407d5113A06",
     "keeperAccessControl": "0x711A339c002386f9db409cA55b6A35a604aB6cF6",
     "guardian": "0x6615e67b8B6b6375D38A0A3f937cd8c1a1e96386",
     "GatedMiniMeController": "0xdDB2dfad74F64F14bb1A1cbaB9C03bc0eed74493",

--- a/scripts/badger/registry.py
+++ b/scripts/badger/registry.py
@@ -22,6 +22,11 @@ def migrate_registry_keys():
     Migrate badger registry v1 keys on a given chain to badger registry v2
     """
 
+    key_replacements = {
+        'devGovernance': 'techOps',
+        'timelock': 'governanceTimelock',
+    }
+
     key_set = set()
 
     key_index = 0
@@ -33,12 +38,9 @@ def migrate_registry_keys():
             # ignore duplicated sanitized keys, only operate on unique values
             if key not in key_set:
                 # smol patchwerk, if we ever need more make a real function (manual migration on new key)
-                if key == 'devGovernance':
+                if key in key_replacements:
                     value = chain_safe.badger.registry.get(key)
-                    expected_value = contract_registry.badger_wallets.techops_multisig
-                    if value != expected_value:
-                        raise Exception(f"Invalid key value found on {key}: found {value}, expected: {expected_value}")
-                    key = 'techOps'
+                    key = key_replacements[key]
                     chain_safe.badger.set_key_on_registry(key, value)
                 else:
                     chain_safe.badger.migrate_key_on_registry(key)

--- a/scripts/badger/registry.py
+++ b/scripts/badger/registry.py
@@ -27,13 +27,16 @@ def migrate_registry_keys():
         try:
             key = chain_safe.badger.registry.keys(key_index)
 
-            # smol patchwerk, if we ever need more make a real function
+            # smol patchwerk, if we ever need more make a real function (manual migration on new key)
             if key == 'devGovernance':
+                value = chain_safe.badger.registry.get(key)
                 key = 'techOps'
+                chain_safe.badger.set_key_on_registry(key, value)
+            else:
+                chain_safe.badger.migrate_key_on_registry(key)
+            key_index += 1
         except:
             break
-        chain_safe.badger.migrate_key_on_registry(key)
-        key_index += 1
 
     # try to simulate tx and see dafuq
     chain_safe.post_safe_tx()

--- a/scripts/badger/registry.py
+++ b/scripts/badger/registry.py
@@ -27,6 +27,11 @@ def migrate_registry_keys():
         'timelock': 'governanceTimelock',
     }
 
+    key_lookups = {
+        'techOps': contract_registry.badger_wallets.techops_multisig,
+        'governanceTimelock': contract_registry.governance_timelock,
+    }
+
     key_set = set()
 
     key_index = 0
@@ -37,8 +42,9 @@ def migrate_registry_keys():
 
             # ignore duplicated sanitized keys, only operate on unique values
             if key not in key_set:
-                # smol patchwerk, if we ever need more make a real function (manual migration on new key)
-                if key in key_replacements:
+                should_replace = key in key_replacements
+                print(f"Migrating new unique key: {key} {'with' if should_replace else 'without'} replacement")
+                if should_replace:
                     value = chain_safe.badger.registry.get(key)
                     key = key_replacements[key]
                     chain_safe.badger.set_key_on_registry(key, value)
@@ -48,7 +54,8 @@ def migrate_registry_keys():
                 key_set.add(key)
 
             key_index += 1
-        except:
+        except Exception as e:
+            print(e)
             break
 
     # try to simulate tx and see dafuq

--- a/scripts/badger/registry.py
+++ b/scripts/badger/registry.py
@@ -22,18 +22,29 @@ def migrate_registry_keys():
     Migrate badger registry v1 keys on a given chain to badger registry v2
     """
 
+    key_set = set()
+
     key_index = 0
     while True:
         try:
-            key = chain_safe.badger.registry.keys(key_index)
+            # # some registry keys are duplicated with surrounding quotes, let's remove and dedup
+            key = chain_safe.badger.registry.keys(key_index).replace("\"", "")
 
-            # smol patchwerk, if we ever need more make a real function (manual migration on new key)
-            if key == 'devGovernance':
-                value = chain_safe.badger.registry.get(key)
-                key = 'techOps'
-                chain_safe.badger.set_key_on_registry(key, value)
-            else:
-                chain_safe.badger.migrate_key_on_registry(key)
+            # ignore duplicated sanitized keys, only operate on unique values
+            if key not in key_set:
+                # smol patchwerk, if we ever need more make a real function (manual migration on new key)
+                if key == 'devGovernance':
+                    value = chain_safe.badger.registry.get(key)
+                    expected_value = contract_registry.badger_wallets.techops_multisig
+                    if value != expected_value:
+                        raise Exception(f"Invalid key value found on {key}: found {value}, expected: {expected_value}")
+                    key = 'techOps'
+                    chain_safe.badger.set_key_on_registry(key, value)
+                else:
+                    chain_safe.badger.migrate_key_on_registry(key)
+
+                key_set.add(key)
+
             key_index += 1
         except:
             break

--- a/scripts/badger/registry.py
+++ b/scripts/badger/registry.py
@@ -26,6 +26,10 @@ def migrate_registry_keys():
     while True:
         try:
             key = chain_safe.badger.registry.keys(key_index)
+
+            # smol patchwerk, if we ever need more make a real function
+            if key == 'devGovernance':
+                key = 'techOps'
         except:
             break
         chain_safe.badger.migrate_key_on_registry(key)

--- a/scripts/badger/registry.py
+++ b/scripts/badger/registry.py
@@ -47,6 +47,8 @@ def migrate_registry_keys():
                 if should_replace:
                     value = chain_safe.badger.registry.get(key)
                     key = key_replacements[key]
+                    if key in key_lookups:
+                        value = key_lookups[key]
                     chain_safe.badger.set_key_on_registry(key, value)
                 else:
                     chain_safe.badger.migrate_key_on_registry(key)


### PR DESCRIPTION
# Summary

Migrate registry to registry v2 on Arbitrum.

## Posting

```
brownie run scripts/badger/registry.py migrate_registry_keys --network abitrum-main-fork
```

Satisfies a partial of #365 