### PR TITLE
Unstake aurabal and lock aura rewards

### DIFF
--- a/scripts/issue/608/unstake_aurabal_and_rewards.py
+++ b/scripts/issue/608/unstake_aurabal_and_rewards.py
@@ -1,0 +1,16 @@
+from brownie import accounts
+
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import r
+
+
+def main():
+    voter = GreatApeSafe(r.badger_wallets.treasury_voter_multisig)
+    voter.take_snapshot(tokens=[r.treasury_tokens.AURABAL])
+
+    aurabal_staking = voter.contract(r.aura.aurabal_staking)
+
+    aurabal_staking.withdraw(aurabal_staking.balanceOf(voter), True, True)
+    assert aurabal_staking.balanceOf(voter) == 0
+
+    voter.post_safe_tx()


### PR DESCRIPTION
Tackles #608 

```
brownie run issue/608/unstake_aurabal_and_rewards
```

**Note:** for the time being on gauge uncertainty, we leave naked the aurabal position in the msig