### PR TITLE
script: cancel q2 upkeep and register new ones for q3

### DIFF
--- a/great_ape_safe/ape_api/badger.py
+++ b/great_ape_safe/ape_api/badger.py
@@ -3,6 +3,7 @@ import os
 import requests
 from decimal import Decimal
 
+import pandas as pd
 from brownie import chain, interface, ZERO_ADDRESS
 from eth_abi import encode_abi
 
@@ -45,6 +46,7 @@ class Badger():
         self.registry_v2 = self.safe.contract(
             r.registry_v2, interface.IBadgerRegistryV2
         )
+        self.station = self.safe.contract(r.badger_wallets.gas_station)
 
         # misc
         self.api_url = 'https://api.badger.com/v2/'
@@ -317,3 +319,26 @@ class Badger():
         assert self.bribes_processor.getOrderID(order_payload) == order_uid
 
         return order_payload, order_uid
+
+
+    def set_gas_station_watchlist(self):
+        labels, addrs, min_bals, min_top_ups = [], [], [], []
+        for label, addr in r.badger_wallets.items():
+            min_bal = 2e18
+            min_top_up = .5e18
+            if not label.startswith('ops_') or 'multisig' in label:
+                continue
+            if 'executor' in label:
+                min_bal = 1e18
+            if label == 'ops_botsquad':
+                min_bal = 5e18
+            if label == 'ops_deployer':
+                min_bal = 5e18
+            labels.append(label)
+            addrs.append(addr)
+            min_bals.append(min_bal)
+            min_top_ups.append(min_top_up)
+        print(pd.DataFrame(
+            {'addrs': addrs, 'min_bals': min_bals, 'min_top_ups': min_top_ups}, index=labels
+        ))
+        self.station.setWatchList(addrs, min_bals, min_top_ups)

--- a/great_ape_safe/ape_api/chainlink.py
+++ b/great_ape_safe/ape_api/chainlink.py
@@ -1,5 +1,5 @@
 from brownie import interface
-from helpers.addresses import registry
+from helpers.addresses import r
 
 
 class Chainlink:
@@ -7,13 +7,14 @@ class Chainlink:
         self.safe = safe
 
         # contracts
-        self.relayer = interface.IUpkeepRegistrationRequests(
-                registry.eth.chainlink.upkeep_registration_requests,
-                owner=safe.account
-            )
-        self.link = interface.ILinkToken(
-            registry.eth.treasury_tokens.LINK, owner=safe.account
+        self.relayer = self.safe.contract(
+            r.chainlink.upkeep_registration_requests,
+            interface.IUpkeepRegistrationRequests
         )
+        self.link = self.safe.contract(
+            r.treasury_tokens.LINK, interface.ILinkToken
+        )
+        self.keeper_registry = self.safe.contract(r.chainlink.keeper_registry)
 
 
     def register_upkeep(

--- a/scripts/issue/569/transition_dripper_upkeeps.py
+++ b/scripts/issue/569/transition_dripper_upkeeps.py
@@ -43,33 +43,17 @@ def register_q3(sim=False):
     SAFE.chainlink.keeper_registry.withdrawFunds(UPKEEP_ID_TREE_22Q2, SAFE)
 
     # register upkeeps for new drippers
-    LINK.transferAndCall(
-        RELAYER,
-        LINK_MANTISSA,
-        RELAYER.register.encode_input(
-            'TreeDripper2022Q3', # string memory name,
-            b'', # bytes calldata encryptedEmail,
-            r.drippers.tree_2022_q3, # address upkeepContract,
-            300_000, # uint32 gasLimit,
-            SAFE.address, # address adminAddress,
-            b'', # bytes calldata checkData,
-            LINK_MANTISSA, # uint96 amount,
-            0 # uint8 source
-        )
+    SAFE.chainlink.register_upkeep(
+        'TreeDripper2022Q3',
+        r.drippers.tree_2022_q3,
+        300_000,
+        LINK_MANTISSA
     )
-    LINK.transferAndCall(
-        RELAYER,
-        LINK_MANTISSA,
-        RELAYER.register.encode_input(
-            'RemBadgerDripper2022Q3', # string memory name,
-            b'', # bytes calldata encryptedEmail,
-            r.drippers.rembadger_2022_q3, # address upkeepContract,
-            300_000, # uint32 gasLimit,
-            SAFE.address, # address adminAddress,
-            b'', # bytes calldata checkData,
-            LINK_MANTISSA, # uint96 amount,
-            0 # uint8 source
-        )
+    SAFE.chainlink.register_upkeep(
+        'RemBadgerDripper2022Q3',
+        r.drippers.rembadger_2022_q3,
+        300_000,
+        LINK_MANTISSA
     )
 
     # maintenance on the gas station; top up with ether and update watchlist

--- a/scripts/issue/569/transition_dripper_upkeeps.py
+++ b/scripts/issue/569/transition_dripper_upkeeps.py
@@ -1,0 +1,82 @@
+'''
+ref: https://github.com/smartcontractkit/keeper/blob/master/contracts/UpkeepRegistrationRequests.sol
+'''
+
+from brownie import chain, interface
+
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import r
+
+
+LINK_MANTISSA = 75e18
+UPKEEP_ID_TREE_22Q2 = 87 # https://keepers.chain.link/mainnet/87
+
+SAFE = GreatApeSafe(r.badger_wallets.techops_multisig)
+RELAYER = SAFE.contract(
+    r.chainlink.upkeep_registration_requests,
+    interface.IUpkeepRegistrationRequests
+)
+LINK = SAFE.contract(r.treasury_tokens.LINK, interface.ILinkToken)
+STATION = SAFE.contract(r.badger_wallets.gas_station)
+
+SAFE.init_badger()
+SAFE.init_chainlink()
+
+
+def sim():
+    cancel_q2(sim=True)
+    # need 50 blocks between cancel and link retrieval
+    chain.mine(51)
+    register_q3(sim=True)
+
+
+def cancel_q2(sim=False):
+    # cancel tree dripper q2
+    SAFE.take_snapshot([LINK])
+    SAFE.chainlink.keeper_registry.cancelUpkeep(UPKEEP_ID_TREE_22Q2)
+    if not sim:
+        SAFE.post_safe_tx(call_trace=True)
+
+
+def register_q3(sim=False):
+    # retrieve link
+    SAFE.chainlink.keeper_registry.withdrawFunds(UPKEEP_ID_TREE_22Q2, SAFE)
+
+    # register upkeeps for new drippers
+    LINK.transferAndCall(
+        RELAYER,
+        LINK_MANTISSA,
+        RELAYER.register.encode_input(
+            'TreeDripper2022Q3', # string memory name,
+            b'', # bytes calldata encryptedEmail,
+            r.drippers.tree_2022_q3, # address upkeepContract,
+            300_000, # uint32 gasLimit,
+            SAFE.address, # address adminAddress,
+            b'', # bytes calldata checkData,
+            LINK_MANTISSA, # uint96 amount,
+            0 # uint8 source
+        )
+    )
+    LINK.transferAndCall(
+        RELAYER,
+        LINK_MANTISSA,
+        RELAYER.register.encode_input(
+            'RemBadgerDripper2022Q3', # string memory name,
+            b'', # bytes calldata encryptedEmail,
+            r.drippers.rembadger_2022_q3, # address upkeepContract,
+            300_000, # uint32 gasLimit,
+            SAFE.address, # address adminAddress,
+            b'', # bytes calldata checkData,
+            LINK_MANTISSA, # uint96 amount,
+            0 # uint8 source
+        )
+    )
+
+    # maintenance on the gas station; top up with ether and update watchlist
+    SAFE.account.transfer(STATION, SAFE.account.balance())
+    SAFE.badger.set_gas_station_watchlist()
+
+    if not sim:
+        SAFE.post_safe_tx(call_trace=True)
+    else:
+        SAFE.post_safe_tx(skip_preview=True)


### PR DESCRIPTION
solves issue #569 

canceling an upkeep and retrieving its $link needs to be apart at least 50 blocks:
```
brownie run issue/569/transition_dripper_upkeeps cancel_q2
```
```
brownie run issue/569/transition_dripper_upkeeps register_q3
```
to simulate the whole process:
```
brownie run issue/569/transition_dripper_upkeeps sim
```