### PR TITLE
BauraBAL strategy migration script

### DIFF
--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -272,7 +272,8 @@ ADDRESSES_ETH = {
         "remBADGER": "0x6aF7377b5009d7d154F36FE9e235aE1DA27Aea22",
         "remDIGG": "0x99F39D495C6A5237f43602f3Ab5F49786E46c9B0",
         "bcrvBadger": "0xeC1c717A3b02582A4Aa2275260C583095536b613",
-        "graviAURA": "0xBA485b556399123261a5F9c95d413B4f93107407"
+        "graviAURA": "0xBA485b556399123261a5F9c95d413B4f93107407",
+        "bauraBal": "0x37d9D2C6035b744849C15F1BFEE8F268a20fCBd8"
     },
     "strategies": {
         "native.badger": "0x75b8E21BD623012Efb3b69E1B562465A68944eE6",
@@ -304,7 +305,9 @@ ADDRESSES_ETH = {
         "native.remDigg": "0x4055D395361E73530D43c9D4F18b0668fe4B5b91",
         "native.bcrvBadger": "0x1905FD2D2D09792eE058C2b46a05F11630a1EcA1",
         "native.graviAURA": "0x3c0989eF27e3e3fAb87a2d7C38B35880C90E63b5",
+        "native.bauraBal": "0xED6d51A82065725e283fC035f488213e869FD976",
         "_deprecated": {
+            "native.bauraBal": "0xfB490b5beA343ABAe0E71B61bBdfd4301F5e4df9",
             "native.pbtcCrv": {
                 "v1": "0x1C1fD689103bbFD701b3B7D41A3807F12814033D",
                 "v1.1": "0x3f98F3a21B125414e4740316bd6Ef14718764a22",

--- a/interfaces/badger/IAuraBalStaker.sol
+++ b/interfaces/badger/IAuraBalStaker.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.7.0 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+import {BaseStrategy} from "./IVestedAura.sol";
+
+interface IAuraBalStaker {
+    event Paused(address account);
+    event SetWithdrawalMaxDeviationThreshold(uint256 newMaxDeviationThreshold);
+    event Unpaused(address account);
+
+    function AURA() external view returns (address);
+
+    function AURABAL() external view returns (address);
+
+    function AURABAL_BALETH_BPT_POOL_ID() external view returns (bytes32);
+
+    function AURABAL_REWARDS() external view returns (address);
+
+    function BAL() external view returns (address);
+
+    function BALANCER_VAULT() external view returns (address);
+
+    function BALETH_BPT() external view returns (address);
+
+    function BAL_ETH_POOL_ID() external view returns (bytes32);
+
+    function BB_A_USD() external view returns (address);
+
+    function GRAVIAURA() external view returns (address);
+
+    function MAX_BPS() external view returns (uint256);
+
+    function WETH() external view returns (address);
+
+    function __BaseStrategy_init(address _vault) external;
+
+    function autoCompoundRatio() external view returns (uint256);
+
+    function balEthBptToAuraBalMinOutBps() external view returns (uint256);
+
+    function balanceOf() external view returns (uint256);
+
+    function balanceOfPool() external view returns (uint256);
+
+    function balanceOfRewards()
+        external
+        view
+        returns (BaseStrategy.TokenAmount[] memory rewards);
+
+    function balanceOfWant() external view returns (uint256);
+
+    function baseStrategyVersion() external pure returns (string memory);
+
+    function claimRewardsOnWithdrawAll() external view returns (bool);
+
+    function deposit() external;
+
+    function earn() external;
+
+    function emitNonProtectedToken(address _token) external;
+
+    function getMintableAuraRewards(uint256 _balAmount)
+        external
+        view
+        returns (uint256 amount);
+
+    function getName() external pure returns (string memory);
+
+    function getProtectedTokens() external view returns (address[] memory);
+
+    function governance() external view returns (address);
+
+    function guardian() external view returns (address);
+
+    function harvest()
+        external
+        returns (BaseStrategy.TokenAmount[] memory harvested);
+
+    function initialize(address _vault) external;
+
+    function isProtectedToken(address token) external view returns (bool);
+
+    function isTendable() external pure returns (bool);
+
+    function keeper() external view returns (address);
+
+    function pause() external;
+
+    function paused() external view returns (bool);
+
+    function setBalEthBptToAuraBalMinOutBps(uint256 _minOutBps) external;
+
+    function setClaimRewardsOnWithdrawAll(bool _claimRewardsOnWithdrawAll)
+        external;
+
+    function setWithdrawalMaxDeviationThreshold(uint256 _threshold) external;
+
+    function strategist() external view returns (address);
+
+    function tend() external returns (BaseStrategy.TokenAmount[] memory tended);
+
+    function unpause() external;
+
+    function vault() external view returns (address);
+
+    function want() external view returns (address);
+
+    function withdraw(uint256 _amount) external;
+
+    function withdrawOther(address _asset) external;
+
+    function withdrawToVault() external;
+
+    function withdrawalMaxDeviationThreshold() external view returns (uint256);
+}

--- a/scripts/issue/633/migrate_baurabal_strategy.py
+++ b/scripts/issue/633/migrate_baurabal_strategy.py
@@ -1,0 +1,97 @@
+from brownie import interface, chain, accounts
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import registry
+from rich.console import Console
+
+C = Console()
+
+AURABAL_STRAT_CURRENT = registry.eth.strategies._deprecated["native.bauraBal"]
+AURABAL_STRAT_NEW = registry.eth.strategies["native.bauraBal"]
+BAURA_BAL = registry.eth.sett_vaults.bauraBal
+DEV_MULTI = registry.eth.badger_wallets.dev_multisig
+BADGERTREE = registry.eth.badger_wallets.badgertree
+TROPS = registry.eth.badger_wallets.treasury_ops_multisig
+
+USER = "0xdE0AEf70a7ae324045B7722C903aaaec2ac175F5"
+
+def main(simulation="false"):
+    safe = GreatApeSafe(registry.eth.badger_wallets.dev_multisig)
+    auraBal_strat_current = interface.IAuraBalStaker(AURABAL_STRAT_CURRENT, owner=safe.account)
+    auraBal_strat_new = interface.IAuraBalStaker(AURABAL_STRAT_NEW, owner=safe.account)
+    auraBal_vault = interface.ITheVault(BAURA_BAL, owner=safe.account)
+    want = interface.ERC20(auraBal_vault.token())
+    bb_a_usd = interface.ERC20(auraBal_strat_new.BB_A_USD())
+
+    ## Check integrity
+    assert auraBal_vault.strategy() == auraBal_strat_current.address
+
+    assert auraBal_strat_new.want() == auraBal_strat_current.want()
+    assert auraBal_strat_new.vault() == auraBal_strat_current.vault()
+    assert (
+        auraBal_strat_new.withdrawalMaxDeviationThreshold()
+        == auraBal_strat_current.withdrawalMaxDeviationThreshold()
+    )
+    assert auraBal_strat_new.autoCompoundRatio() == auraBal_strat_current.autoCompoundRatio()
+    assert (
+        auraBal_strat_new.claimRewardsOnWithdrawAll()
+        == auraBal_strat_current.claimRewardsOnWithdrawAll()
+    )
+    assert (
+        auraBal_strat_new.balEthBptToAuraBalMinOutBps()
+        == auraBal_strat_current.balEthBptToAuraBalMinOutBps()
+    )
+
+    ## Harvest current strat
+    prev_bbausd_strat_balance = bb_a_usd.balanceOf(AURABAL_STRAT_CURRENT)
+    auraBal_strat_current.harvest()
+    assert bb_a_usd.balanceOf(AURABAL_STRAT_CURRENT) > prev_bbausd_strat_balance
+
+    ## Emit all accumulated bb_a_usd on the strat to this point (Will process perf fees)
+    prev_bbausd_tree_balance = bb_a_usd.balanceOf(BADGERTREE)
+    prev_bbausd_trops_balance = bb_a_usd.balanceOf(TROPS)
+    auraBal_vault.emitNonProtectedToken(bb_a_usd.address)
+    assert bb_a_usd.balanceOf(BADGERTREE) > prev_bbausd_tree_balance
+    assert bb_a_usd.balanceOf(TROPS) > prev_bbausd_trops_balance # Fees
+    assert bb_a_usd.balanceOf(AURABAL_STRAT_CURRENT) == 0 # All assets are emitted
+    assert bb_a_usd.balanceOf(BAURA_BAL) == 0 # All assets are emitted
+
+    ## withdrawToVault
+    prev_strat_balance = auraBal_strat_current.balanceOf() # balanceOfWant().add(balanceOfPool());
+    prev_vault_balance = want.balanceOf(BAURA_BAL)
+    auraBal_vault.withdrawToVault()
+    assert want.balanceOf(BAURA_BAL) == prev_strat_balance + prev_vault_balance
+    assert auraBal_strat_current.balanceOf() == 0
+
+    # setStrategy
+    assert auraBal_strat_current.want() == auraBal_strat_new.want() # Confirm strategy
+    auraBal_vault.setStrategy(AURABAL_STRAT_NEW)
+    assert auraBal_vault.strategy() == auraBal_strat_new.address
+
+    # Earn to new strat
+    prev_available = auraBal_vault.available()
+    prev_strat_balance = auraBal_strat_new.balanceOf()
+    auraBal_vault.earn()
+    assert auraBal_strat_new.balanceOf() == prev_available + prev_strat_balance
+
+    # Run a few test actions
+    if simulation == "true":
+        chain.sleep(13*100)
+        chain.mine()
+
+        # Harvest
+        tx = auraBal_strat_new.harvest()
+        assert len(tx.events["TreeDistribution"]) == 2 # graviAURA and bBB_A_USD
+        assert bb_a_usd.balanceOf(AURABAL_STRAT_NEW) == 0 # All BB_A_USD gets processed
+
+        chain.sleep(13*100)
+        chain.mine()
+
+        # Withdraw
+        user = accounts.at(USER, force=True)
+        prev_user_balance = want.balanceOf(USER)
+        auraBal_vault.withdrawAll({"from": user})
+        assert want.balanceOf(USER) > prev_user_balance
+
+        C.print("[green]Simulation successful![/green]")
+    else:
+        safe.post_safe_tx()

--- a/scripts/issue/633/migrate_baurabal_strategy.py
+++ b/scripts/issue/633/migrate_baurabal_strategy.py
@@ -19,8 +19,8 @@ def main(simulation="false"):
     auraBal_strat_current = interface.IAuraBalStaker(AURABAL_STRAT_CURRENT, owner=safe.account)
     auraBal_strat_new = interface.IAuraBalStaker(AURABAL_STRAT_NEW, owner=safe.account)
     auraBal_vault = interface.ITheVault(BAURA_BAL, owner=safe.account)
-    want = interface.ERC20(auraBal_vault.token())
-    bb_a_usd = interface.ERC20(auraBal_strat_new.BB_A_USD())
+    want = interface.IERC20(auraBal_vault.token())
+    bb_a_usd = interface.IERC20(auraBal_strat_new.BB_A_USD())
 
     ## Check integrity
     assert auraBal_vault.strategy() == auraBal_strat_current.address


### PR DESCRIPTION
This PR tackles issue #633 

To post:
```
brownie run scripts/issue/633/migrate_baurabal_strategy.py
```
To run simulation:
```
brownie run scripts/issue/633/migrate_baurabal_strategy.py main true
```

NOTE: As part of the migration process, the naked bb-a-usd accumulated for the current strat will also be emitted. 