### PR TITLE
[dev multi] Issues 663 - AuraBribesProcessur Setup

### DIFF
--- a/great_ape_safe/ape_api/badger.py
+++ b/great_ape_safe/ape_api/badger.py
@@ -39,8 +39,8 @@ class Badger():
         self.timelock = self.safe.contract(
             r.governance_timelock, interface.IGovernanceTimelock
         )
-        self.bribes_processor = self.safe.contract(
-            r.bribes_processor, interface.IBribesProcessor
+        self.cvx_bribes_processor = self.safe.contract(
+            r.cvx_bribes_processor, interface.IBribesProcessor
         )
         self.registry = self.safe.contract(
             r.registry, interface.IBadgerRegistry
@@ -159,13 +159,13 @@ class Badger():
         if prev_strategy_balance == 0:
             C.print(f"[red]There are no rewards to sweep for: {reward.symbol()}[/red]")
             return 0
-        prev_bribes_processor_balance = reward.balanceOf(self.bribes_processor.address)
+        prev_bribes_processor_balance = reward.balanceOf(self.cvx_bribes_processor.address)
 
         # Sweep the reward token
         self.strat_bvecvx.sweepRewardToken(token_addr)
 
         assert (
-            (reward.balanceOf(self.bribes_processor.address) - prev_bribes_processor_balance) ==
+            (reward.balanceOf(self.cvx_bribes_processor.address) - prev_bribes_processor_balance) ==
             prev_strategy_balance
         )
         assert reward.balanceOf(self.strat_bvecvx.address) == 0
@@ -334,18 +334,18 @@ class Badger():
             mantissa_buy,
             deadline,
             coef,
-            destination=self.bribes_processor.address,
-            origin=self.bribes_processor.address
+            destination=self.cvx_bribes_processor.address,
+            origin=self.cvx_bribes_processor.address
         )
-        order_payload['kind'] = str(self.bribes_processor.KIND_SELL())
-        order_payload['sellTokenBalance'] = str(self.bribes_processor.BALANCE_ERC20())
-        order_payload['buyTokenBalance'] = str(self.bribes_processor.BALANCE_ERC20())
+        order_payload['kind'] = str(self.cvx_bribes_processor.KIND_SELL())
+        order_payload['sellTokenBalance'] = str(self.cvx_bribes_processor.BALANCE_ERC20())
+        order_payload['buyTokenBalance'] = str(self.cvx_bribes_processor.BALANCE_ERC20())
         order_payload.pop('signingScheme')
         order_payload.pop('signature')
         order_payload.pop('from')
         order_payload = tuple(order_payload.values())
 
-        assert self.bribes_processor.getOrderID(order_payload) == order_uid
+        assert self.cvx_bribes_processor.getOrderID(order_payload) == order_uid
 
         return order_payload, order_uid
 

--- a/great_ape_safe/ape_api/badger.py
+++ b/great_ape_safe/ape_api/badger.py
@@ -36,6 +36,9 @@ class Badger():
         self.strat_bvecvx = self.safe.contract(
             r.strategies['native.vestedCVX'], interface.IVestedCvx
         )
+        self.strat_bve_aura = self.safe.contract(
+            r.strategies['native.graviAURA'], interface.IVestedAura
+        )
         self.timelock = self.safe.contract(
             r.governance_timelock, interface.IGovernanceTimelock
         )

--- a/great_ape_safe/ape_api/cow.py
+++ b/great_ape_safe/ape_api/cow.py
@@ -77,7 +77,7 @@ class Cow():
         else:
             buy_amount_after_fee = int(int(r.json()['buyAmountAfterFee']) * coef)
             pricer = interface.IOnChainPricing(
-                interface.IBribesProcessor(registry.eth.bribes_processor).pricer(),
+                interface.IBribesProcessor(registry.eth.cvx_bribes_processor).pricer(),
                 owner=self.safe.account
             )
             naive_quote = pricer.findOptimalSwap(

--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -25,7 +25,8 @@ ADDRESSES_ETH = {
         "rembadger_2022_q3": "0x697A8DebFbb6bE97c821b482AECc30477F40A102",
         "tree_2022_q3": "0x5495BDB1f4c170e5C1A939382041Cf46d7f14EAd",
     },
-    "bribes_processor": "0xb2Bf1d48F2C2132913278672e6924efda3385de2",
+    "cvx_bribes_processor": "0xb2Bf1d48F2C2132913278672e6924efda3385de2",
+    "aura_bribes_processor": "0x0B6198b324E12a002B60162f8A130d6aedABD04C",
     "digg_monetary_policy": "0x327a78D13eA74145cc0C63E6133D516ad3E974c3",
     # the wallets listed here are looped over by scout and checked for all treasury tokens
     "badger_wallets": {

--- a/scripts/badger/process_bribes.py
+++ b/scripts/badger/process_bribes.py
@@ -16,7 +16,7 @@ DEADLINE = 60*60*3
 SAFE = GreatApeSafe(registry.eth.badger_wallets.techops_multisig)
 SAFE.init_badger()
 SAFE.init_cow(prod=COW_PROD)
-PROCESSOR = SAFE.badger.bribes_processor
+PROCESSOR = SAFE.badger.cvx_bribes_processor
 
 WETH = interface.IWETH9(registry.eth.treasury_tokens.WETH, owner=SAFE.account)
 BADGER = interface.ERC20(
@@ -95,7 +95,7 @@ def step1():
     want_to_sell.pop('CVX') # SameBuyAndSellToken
     for _, addr in want_to_sell.items():
         token = SAFE.contract(addr)
-        balance = token.balanceOf(SAFE.badger.bribes_processor)
+        balance = token.balanceOf(SAFE.badger.cvx_bribes_processor)
         if balance == 0:
             continue
         order_payload, order_uid = SAFE.badger.get_order_for_processor(

--- a/scripts/issue/406/upgrade_vestedcvx_strat.py
+++ b/scripts/issue/406/upgrade_vestedcvx_strat.py
@@ -15,7 +15,7 @@ def main(queue="true", simulation="false"):
     safe.init_badger()
 
     strat_proxy = safe.badger.strat_bvecvx
-    bribes_processor = interface.IBribesProcessor(registry.eth.bribes_processor)
+    cvx_bribes_processor = interface.IBribesProcessor(registry.eth.cvx_bribes_processor)
 
     if queue == "true":
         safe.badger.queue_timelock(
@@ -89,10 +89,10 @@ def main(queue="true", simulation="false"):
         assert prev_CVX_EXTRA_BADGER == strat_proxy.BADGER()
 
         ## Verify new Addresses are setup properly
-        assert strat_proxy.BRIBES_PROCESSOR() == bribes_processor.address
+        assert strat_proxy.BRIBES_PROCESSOR() == cvx_bribes_processor.address
 
-        # Verify that the bribes_processor's manager points to the correct multisig
-        assert bribes_processor.manager() == registry.eth.badger_wallets.techops_multisig
+        # Verify that the cvx_bribes_processor's manager points to the correct multisig
+        assert cvx_bribes_processor.manager() == registry.eth.badger_wallets.techops_multisig
 
         # Test chainlink functions
         if simulation == "true":

--- a/scripts/issue/494/upgrade_vestedcvx_strat.py
+++ b/scripts/issue/494/upgrade_vestedcvx_strat.py
@@ -15,7 +15,7 @@ def main(queue="true", simulation="false"):
     safe.init_badger()
 
     strat_proxy = safe.badger.strat_bvecvx
-    bribes_processor = interface.IBribesProcessor(registry.eth.bribes_processor)
+    cvx_bribes_processor = interface.IBribesProcessor(registry.eth.cvx_bribes_processor)
 
     if queue == "true":
         safe.badger.queue_timelock(
@@ -89,10 +89,10 @@ def main(queue="true", simulation="false"):
         assert prev_CVX_EXTRA_BADGER == strat_proxy.BADGER()
 
         ## Verify new Addresses are setup properly
-        assert strat_proxy.BRIBES_PROCESSOR() == bribes_processor.address
+        assert strat_proxy.BRIBES_PROCESSOR() == cvx_bribes_processor.address
 
-        # Verify that the bribes_processor's manager points to the correct multisig
-        assert bribes_processor.manager() == registry.eth.badger_wallets.techops_multisig
+        # Verify that the cvx_bribes_processor's manager points to the correct multisig
+        assert cvx_bribes_processor.manager() == registry.eth.badger_wallets.techops_multisig
 
         # Test chainlink functions
         if simulation == "true":

--- a/scripts/issue/643/lock_half_of_cvx.py
+++ b/scripts/issue/643/lock_half_of_cvx.py
@@ -1,0 +1,90 @@
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import registry
+from brownie import Contract, interface
+
+"""
+  Lock Half of CVX in bveCVX via
+"""
+
+# Assert approximate integer
+def approx(actual, expected, percentage_threshold):
+    print(actual, expected, percentage_threshold)
+    diff = int(abs(actual - expected))
+    # 0 diff should automtically be a match
+    if diff == 0:
+        return True
+    return diff < (actual * percentage_threshold // 100)
+
+
+def main():
+
+    safe = GreatApeSafe(registry.eth.badger_wallets.dev_multisig)
+    safe.init_badger()
+    safe.init_convex()
+
+    ## Check both "rebalacing variables" are false to avoid messing up the math
+    assert safe.badger.strat_bvecvx.processLocksOnRebalance() == False
+    assert safe.badger.strat_bvecvx.harvestOnRebalance() == False
+
+    ## Total Available
+    """
+      From https://etherscan.io/address/0x86ca553d5ae7cd0005552d6e275786d5043800bd#code#F1#L639
+
+    """
+
+    MAX_BPS = safe.badger.strat_bvecvx.MAX_BPS()
+
+    locker = Contract.from_explorer(safe.badger.strat_bvecvx.LOCKER())
+
+    balanceOfWant = safe.badger.strat_bvecvx.balanceOfWant()
+    balanceInLock = locker.balanceOf(safe.badger.strat_bvecvx)
+    totalCVXBalance = balanceOfWant + balanceInLock
+
+    
+
+    ## We want to lock half of what's in the Strategy
+    
+
+
+    ## Our Target is 50% of the CVX in the strat
+    target_amount = balanceOfWant // 2
+
+    ## in BPS
+    as_bps = (target_amount + balanceInLock) * 10_000 // totalCVXBalance 
+
+    print("as_bps")
+    print(as_bps)
+
+    ## Verify math makes sense
+    newLockAmount = totalCVXBalance * as_bps // MAX_BPS
+
+    print("newLockAmount")
+    print(newLockAmount)
+
+    cvxToLock = newLockAmount - balanceInLock
+
+    print("cvxToLock")
+    print(cvxToLock)
+
+    assert approx(cvxToLock, target_amount, 1)
+
+    ## Calculate what half of the strategy is as %, then lock that
+
+    ## Goes to Vault
+    expected_in_vault = balanceOfWant - cvxToLock
+
+    # before_lock_balance = TODO
+
+
+    before_balance_in_vault = safe.convex.cvx.balanceOf(registry.eth.sett_vaults.bveCVX)
+    before_balance_of_locker = safe.convex.cvx.balanceOf(safe.badger.strat_bvecvx.LOCKER())
+
+    
+    ## Lock
+    safe.badger.strat_bvecvx.manualRebalance(as_bps)
+
+    after_balance_in_vault = safe.convex.cvx.balanceOf(registry.eth.sett_vaults.bveCVX)
+    after_balance_of_locker = safe.convex.cvx.balanceOf(safe.badger.strat_bvecvx.LOCKER())
+
+    assert approx(after_balance_in_vault - before_balance_in_vault, expected_in_vault, 1)
+    assert approx(after_balance_of_locker - before_balance_of_locker, cvxToLock, 1)

--- a/scripts/issue/663/set_aura_bribes_processor.py
+++ b/scripts/issue/663/set_aura_bribes_processor.py
@@ -30,3 +30,5 @@ def main():
 
     assert aura_bribes_processor.bribesProcessor() == aura_bribes_processor
 
+    safe.post_safe_tx()
+

--- a/scripts/issue/663/set_aura_bribes_processor.py
+++ b/scripts/issue/663/set_aura_bribes_processor.py
@@ -1,0 +1,32 @@
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import registry
+from brownie import Contract, interface
+from helpers.constants import AddressZero
+
+"""
+  Sets Bribes Processor to target address
+"""
+
+def main():
+    safe = GreatApeSafe(registry.eth.badger_wallets.dev_multisig)
+    safe.init_badger()
+
+    bve_aura = safe.badger.strat_bve_aura
+    tech_ops = registry.eth.badger_wallets.techops_multisig
+
+    aura_bribes_processor = interface.IBribesProcessor(registry.eth.aura_bribes_processor)
+
+    ## Ensure Strategy makes sense
+    assert aura_bribes_processor.STRATEGY() == bve_aura
+
+    ## Ensure delegation has happened (for security reasons)
+    assert aura_bribes_processor.manager() == tech_ops
+
+    ## Because it's setup let's make sure no address was set previously
+    assert aura_bribes_processor.bribesProcessor() == AddressZero
+
+    ## Set it up
+    bve_aura.setBribesProcessor(aura_bribes_processor)
+
+    assert aura_bribes_processor.bribesProcessor() == aura_bribes_processor
+


### PR DESCRIPTION
- Refactors naming of `bribes_processor` to `cvx_bribes_processor`
- Adds `aura_bribes_processor`
- Has script for setting the bribes processor for bveAura

Closes #663 
Sets up Bribes processor
Requirements are in the issue as well

```
brownie run scripts/issue/663/set_aura_bribes_processor.py
```