### PR TITLE
Update threser around block lock and add post trasnfers script

### DIFF
--- a/scripts/badger/post_thresher_transfers.py
+++ b/scripts/badger/post_thresher_transfers.py
@@ -1,0 +1,20 @@
+from brownie import interface
+
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import r
+
+
+def main():
+    safe = GreatApeSafe(r.badger_wallets.treasury_ops_multisig)
+
+    # tokens
+    BCVXCRV = interface.ISettV4h(r.sett_vaults.bcvxCRV, owner=safe.account)
+    BVECVX = interface.ISettV4h(r.sett_vaults.bveCVX, owner=safe.account)
+
+    # bcvxcrv to tree to solve deficit
+    # NOTE: likely after Q4 maybe this line is not relevant anymore
+    BCVXCRV.transfer(r.badger_wallets.badgertree, BCVXCRV.balanceOf(safe))
+    # influce token to voter
+    BVECVX.transfer(r.badger_wallets.treasury_voter_multisig, BVECVX.balanceOf(safe))
+
+    safe.post_safe_tx()

--- a/scripts/badger/thresher.py
+++ b/scripts/badger/thresher.py
@@ -214,10 +214,8 @@ def main():
     SAFE.sushi.xsushi.leave(SAFE.sushi.xsushi.balanceOf(SAFE))
 
     # 6: send all relevant influence tokens to voter
-    SAFE.balancer.claim([BADGER, WBTC])
-    BAL.transfer(VOTER, BAL.balanceOf(SAFE))
     AURABAL.transfer(VOTER, AURABAL.balanceOf(SAFE))
-    BVECVX.transfer(VOTER, BVECVX.balanceOf(SAFE))
+    # BVECVX.transfer(VOTER, BVECVX.balanceOf(SAFE)) cannot transfer in same block as depositing
 
     # 7: send weth to vault
     WETH.transfer(VAULT, WETH.balanceOf(SAFE) * DUSTY)


### PR DESCRIPTION
These changes were used to be able to run the thresher in #511 due to block lock in `bvecvx` 

Added also the script which needs to be run post-thresher and remove the *BAL* claim, since it is likely the last one to come from trops. 