### PR TITLE
Switch AuraBribesProcessor and generalize `get_order_for_processor` function

### DIFF
--- a/great_ape_safe/ape_api/badger.py
+++ b/great_ape_safe/ape_api/badger.py
@@ -351,6 +351,7 @@ class Badger():
 
     def get_order_for_processor(
         self,
+        bribes_processor,
         sell_token,
         mantissa_sell,
         buy_token,
@@ -368,18 +369,18 @@ class Badger():
             mantissa_buy,
             deadline,
             coef,
-            destination=self.cvx_bribes_processor.address,
-            origin=self.cvx_bribes_processor.address
+            destination=bribes_processor.address,
+            origin=bribes_processor.address
         )
-        order_payload['kind'] = str(self.cvx_bribes_processor.KIND_SELL())
-        order_payload['sellTokenBalance'] = str(self.cvx_bribes_processor.BALANCE_ERC20())
-        order_payload['buyTokenBalance'] = str(self.cvx_bribes_processor.BALANCE_ERC20())
+        order_payload['kind'] = str(bribes_processor.KIND_SELL())
+        order_payload['sellTokenBalance'] = str(bribes_processor.BALANCE_ERC20())
+        order_payload['buyTokenBalance'] = str(bribes_processor.BALANCE_ERC20())
         order_payload.pop('signingScheme')
         order_payload.pop('signature')
         order_payload.pop('from')
         order_payload = tuple(order_payload.values())
 
-        assert self.cvx_bribes_processor.getOrderID(order_payload) == order_uid
+        assert bribes_processor.getOrderID(order_payload) == order_uid
 
         return order_payload, order_uid
 

--- a/great_ape_safe/ape_api/cow.py
+++ b/great_ape_safe/ape_api/cow.py
@@ -50,7 +50,7 @@ class Cow():
         destination = self.safe.address if not destination else destination
 
         # make sure mantissa is an integer
-        mantissa_sell == int(mantissa_sell)
+        mantissa_sell = int(mantissa_sell)
 
         # get the fee and exact amount to buy after fee
         fee_and_quote_payload = {

--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -28,7 +28,7 @@ ADDRESSES_ETH = {
         "tree_2022_q3": "0x5495BDB1f4c170e5C1A939382041Cf46d7f14EAd",
     },
     "cvx_bribes_processor": "0xb2Bf1d48F2C2132913278672e6924efda3385de2",
-    "aura_bribes_processor": "0x0B6198b324E12a002B60162f8A130d6aedABD04C",
+    "aura_bribes_processor": "0xC66C9F87d847dDc964724B789D3113885b08efCF",
     "digg_monetary_policy": "0x327a78D13eA74145cc0C63E6133D516ad3E974c3",
     # the wallets listed here are looped over by scout and checked for all treasury tokens
     "badger_wallets": {

--- a/scripts/badger/process_bribes_bvecvx.py
+++ b/scripts/badger/process_bribes_bvecvx.py
@@ -53,6 +53,7 @@ def step0_1(sim=False):
 
     for addr, mantissa in claimed.items():
         order_payload, order_uid = SAFE.badger.get_order_for_processor(
+            PROCESSOR,
             sell_token=SAFE.contract(addr),
             mantissa_sell=mantissa,
             buy_token=WETH,
@@ -117,6 +118,7 @@ def step2():
     assert badger_share + cvx_share == weth_total
 
     order_payload, order_uid = SAFE.badger.get_order_for_processor(
+        PROCESSOR,
         sell_token=WETH,
         mantissa_sell=badger_share,
         buy_token=BADGER,
@@ -127,6 +129,7 @@ def step2():
     PROCESSOR.swapWethForBadger(order_payload, order_uid)
 
     order_payload, order_uid = SAFE.badger.get_order_for_processor(
+        PROCESSOR,
         sell_token=WETH,
         mantissa_sell=cvx_share,
         buy_token=CVX,

--- a/scripts/badger/process_bribes_graviaura.py
+++ b/scripts/badger/process_bribes_graviaura.py
@@ -41,6 +41,7 @@ def claim_and_sell_for_weth():
         addr = web3.toChecksumAddress(addr)
         if addr != BADGER.address and addr != AURA.address:
             order_payload, order_uid = SAFE.badger.get_order_for_processor(
+                PROCESSOR,
                 sell_token=SAFE.contract(addr),
                 mantissa_sell=int(mantissa),
                 buy_token=WETH,
@@ -60,6 +61,7 @@ def sell_weth():
     assert badger_share + aura_share == weth_total
 
     order_payload, order_uid = SAFE.badger.get_order_for_processor(
+        PROCESSOR,
         sell_token=WETH,
         mantissa_sell=badger_share,
         buy_token=BADGER,
@@ -70,6 +72,7 @@ def sell_weth():
     PROCESSOR.swapWethForBadger(order_payload, order_uid)
 
     order_payload, order_uid = SAFE.badger.get_order_for_processor(
+        PROCESSOR,
         sell_token=WETH,
         mantissa_sell=aura_share,
         buy_token=AURA,

--- a/scripts/badger/process_bribes_graviaura.py
+++ b/scripts/badger/process_bribes_graviaura.py
@@ -43,7 +43,7 @@ def claim_and_sell_for_weth():
             order_payload, order_uid = SAFE.badger.get_order_for_processor(
                 PROCESSOR,
                 sell_token=SAFE.contract(addr),
-                mantissa_sell=int(mantissa),
+                mantissa_sell=mantissa,
                 buy_token=WETH,
                 deadline=DEADLINE,
                 coef=COEF,

--- a/scripts/issue/698/set_gravi_processor.py
+++ b/scripts/issue/698/set_gravi_processor.py
@@ -1,0 +1,22 @@
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import r
+from scripts.badger.process_bribes_graviaura import claim_and_sell_for_weth
+
+NEW_PROCESSOR = r.aura_bribes_processor
+
+def main(simulation="false"):
+    safe = GreatApeSafe(r.badger_wallets.dev_multisig)
+    safe.init_badger()
+
+    processor = safe.contract(NEW_PROCESSOR)
+    assert processor.manager() == r.badger_wallets.techops_multisig
+
+    safe.badger.strat_graviaura.setBribesProcessor(NEW_PROCESSOR)
+
+    if simulation == "true":
+        # Call was currently broken with previous version since the `getHash` function had 
+        # the wrong encoding. Calling after switching processor to confirm that the flow will
+        # work properly.
+        claim_and_sell_for_weth()
+    else:
+        safe.post_safe_tx(call_trace=True)


### PR DESCRIPTION
Tackles issues #698 and #699 

Run with:
```
brownie run scripts/issue/698/set_gravi_processor.py
```

- Included changes from #694 to generalize the `get_order_for_processor` function in order to properly simulate post Processor switching
- Included a simulation for this, run with:
```
brownie run scripts/issue/698/set_gravi_processor.py main true
```