### PR TITLE
`print_snapshot` hotfix

### DIFF
--- a/great_ape_safe/great_ape_safe.py
+++ b/great_ape_safe/great_ape_safe.py
@@ -173,7 +173,7 @@ class GreatApeSafe(ApeSafe):
 
 
     def print_snapshot(self, csv_destination=None):
-        if 'init_snapshot' in self.__dir__():
+        if not isinstance(self.snapshot, pd.DataFrame):
             return
         if self.snapshot is None:
             raise


### PR DESCRIPTION
`print_snapshot` functionality is blocked from [changes here](https://github.com/Badger-Finance/badger-multisig/pull/686/commits/119dfc62c506ec4d35b987760e33a1ba52496b44) ([rationale here](https://github.com/Badger-Finance/badger-multisig/pull/686#discussion_r935786358)). fixed by using `isinstance` instead for snapshot check