### PR TITLE
feat: aura vaults promotion script

### DIFF
--- a/scripts/issue/732/promote_aura_vaults.py
+++ b/scripts/issue/732/promote_aura_vaults.py
@@ -1,0 +1,32 @@
+from brownie import interface
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import registry
+from rich.console import Console
+
+C = Console()
+
+TECH_OPS = registry.eth.badger_wallets.techops_multisig
+DEV = registry.eth.badger_wallets.dev_multisig
+REGISTRY = registry.eth.registry_v2
+VAULTS = registry.eth.sett_vaults
+STATUS = 1 # Guarded
+VAULT_IDS = [
+    "bauraBal",
+    "b80BADGER_20WBTC",
+    "b40WBTC_40DIGG_20graviAURA",
+    "bBB_a_USD",
+    "b33auraBAL_33graviAURA_33WETH"
+]
+
+def main():
+    safe = GreatApeSafe(TECH_OPS)
+    safe.init_badger()
+
+    registry = safe.contract(REGISTRY)
+
+    for id in VAULT_IDS:
+        info = registry.productionVaultInfoByVault(VAULTS[id])
+        safe.badger.promote_vault(info[0], info[1], info[3], STATUS)
+        assert registry.productionVaultInfoByVault(VAULTS[id])[2] == STATUS
+
+    safe.post_safe_tx()

--- a/scripts/issue/732/promote_aura_vaults.py
+++ b/scripts/issue/732/promote_aura_vaults.py
@@ -9,7 +9,7 @@ TECH_OPS = registry.eth.badger_wallets.techops_multisig
 DEV = registry.eth.badger_wallets.dev_multisig
 REGISTRY = registry.eth.registry_v2
 VAULTS = registry.eth.sett_vaults
-STATUS = 1 # Guarded
+STATUS = 2 # Guarded
 VAULT_IDS = [
     "bauraBal",
     "b80BADGER_20WBTC",


### PR DESCRIPTION
Tackles #732 

Promotes the following vaults to guarded state:
```
    "bauraBal",
    "b80BADGER_20WBTC",
    "b40WBTC_40DIGG_20graviAURA",
    "bBB_a_USD",
    "b33auraBAL_33graviAURA_33WETH"
```

Run with:
```
brownie run scripts/issue/732/promote_aura_vaults.py
```