### PR TITLE
RegistryV2 and Guestlist scripts library

### DIFF
--- a/great_ape_safe/ape_api/badger.py
+++ b/great_ape_safe/ape_api/badger.py
@@ -416,3 +416,23 @@ class Badger():
             {'addrs': addrs, 'min_bals': min_bals, 'min_top_ups': min_top_ups}, index=labels
         ))
         self.station.setWatchList(addrs, min_bals, min_top_ups)
+
+    
+    def set_guestlist_user_cap(self, guestlist, cap):
+        guestlist = interface.IVipCappedGuestListBbtcUpgradeable(
+            guestlist,
+            owner=self.safe.account
+        )
+        guestlist.setUserDepositCap(cap)
+        assert guestlist.userDepositCap() == cap
+        C.print(f'[green]New user cap: {cap}[/green]')
+
+
+    def set_guestlist_total_cap(self, guestlist, cap):
+        guestlist = interface.IVipCappedGuestListBbtcUpgradeable(
+            guestlist,
+            owner=self.safe.account
+        )
+        guestlist.setTotalDepositCap(cap)
+        assert guestlist.totalDepositCap() == cap
+        C.print(f'[green]New total cap: {cap}[/green]')

--- a/interfaces/badger/IVipCappedGuestListBbtcUpgradeable.sol
+++ b/interfaces/badger/IVipCappedGuestListBbtcUpgradeable.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
+
+interface IVipCappedGuestListBbtcUpgradeable {
+    event OwnershipTransferred(
+        address indexed previousOwner,
+        address indexed newOwner
+    );
+    event ProveInvitation(address indexed account, bytes32 indexed guestRoot);
+    event SetGeyser(address geyser);
+    event SetGuestRoot(bytes32 indexed guestRoot);
+    event SetTotalDepositCap(uint256 cap);
+    event SetUserDepositCap(uint256 cap);
+
+    function authorized(
+        address _guest,
+        uint256 _amount,
+        bytes32[] calldata _merkleProof
+    ) external view returns (bool);
+
+    function geyser() external view returns (address);
+
+    function guestRoot() external view returns (bytes32);
+
+    function guests(address) external view returns (bool);
+
+    function initialize(address wrapper_) external;
+
+    function owner() external view returns (address);
+
+    function proveInvitation(address account, bytes32[] calldata merkleProof)
+        external;
+
+    function remainingTotalDepositAllowed() external view returns (uint256);
+
+    function remainingUserDepositAllowed(address user)
+        external
+        view
+        returns (uint256);
+
+    function renounceOwnership() external;
+
+    function setGuestRoot(bytes32 guestRoot_) external;
+
+    function setGuests(address[] calldata _guests, bool[] calldata _invited)
+        external;
+
+    function setTotalDepositCap(uint256 cap_) external;
+
+    function setUserDepositCap(uint256 cap_) external;
+
+    function setWrapper(address wrapper_) external;
+
+    function totalDepositCap() external view returns (uint256);
+
+    function transferOwnership(address newOwner) external;
+
+    function userDepositCap() external view returns (uint256);
+
+    function wrapper() external view returns (address);
+}

--- a/scripts/badger/guestlist.py
+++ b/scripts/badger/guestlist.py
@@ -1,0 +1,69 @@
+from rich.console import Console
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import get_registry as registry
+from helpers.constants import MaxUint256, AddressZero
+
+C = Console()
+
+# assuming techOps
+r = registry()
+SAFE = GreatApeSafe(r.badger_wallets.techops_multisig)
+SAFE.init_badger()
+
+# Add the vaults addresses to remove caps from
+VAULTS_ARRAY = ["0xf8f5677B6bCecdb9be94AE8f6770a05a6C53C378"]
+
+# Sets a new user cap for a given vault
+def set_vault_user_cap(vault, cap):
+    vault = SAFE.contract(vault)
+    guestlist = vault.guestList()
+    if guestlist != AddressZero:
+        C.print(f"Guestlist: {guestlist}")
+        SAFE.badger.set_guestlist_user_cap(guestlist, cap)
+    else:
+        C.print(f"[red]No guestlist set for this vault![/red]")
+
+    SAFE.post_safe_tx()
+
+# Sets a new total cap for a given vault
+def set_vault_total_cap(vault, cap):
+    vault = SAFE.contract(vault)
+    guestlist = vault.guestList()
+    if guestlist != AddressZero:
+        C.print(f"Guestlist: {guestlist}")
+        SAFE.badger.set_guestlist_total_cap(guestlist, cap)
+    else:
+        C.print(f"[red]No guestlist set for this vault![/red]")
+
+    SAFE.post_safe_tx()
+
+# Sets the user and total cap to MAXUINT256 for a given vault
+def remove_caps_for_vault(vault):
+    vault = SAFE.contract(vault)
+    guestlist = vault.guestList()
+    if guestlist != AddressZero:
+        C.print(f"Guestlist: {guestlist}")
+        SAFE.badger.set_guestlist_total_cap(guestlist, int(MaxUint256))
+        SAFE.badger.set_guestlist_user_cap(guestlist, int(MaxUint256))
+    else:
+        C.print(f"[red]No guestlist set for this vault![/red]")
+
+    SAFE.post_safe_tx()
+
+# Sets the user and total cap to MAXUINT256 for a batch of vaults
+def remove_caps_for_vaults():
+    if VAULTS_ARRAY:
+        for vault in VAULTS_ARRAY:
+            vault = SAFE.contract(vault)
+            C.print(f"Vault: {vault}")
+            guestlist = vault.guestList()
+            if guestlist != AddressZero:
+                C.print(f"Guestlist: {guestlist}")
+                SAFE.badger.set_guestlist_total_cap(guestlist, int(MaxUint256))
+                SAFE.badger.set_guestlist_user_cap(guestlist, int(MaxUint256))
+            else:
+                C.print(f"[red]No guestlist set for this vault ({vault})![/red]")
+    else:
+        C.print(f"[red]Make sure to add your vaults to the array![/red]")
+
+    SAFE.post_safe_tx()

--- a/scripts/badger/guestlist.py
+++ b/scripts/badger/guestlist.py
@@ -11,7 +11,7 @@ SAFE = GreatApeSafe(r.badger_wallets.techops_multisig)
 SAFE.init_badger()
 
 # Add the vaults addresses to remove caps from
-VAULTS_ARRAY = ["0xf8f5677B6bCecdb9be94AE8f6770a05a6C53C378"]
+VAULTS_ARRAY = []
 
 # Sets a new user cap for a given vault
 def set_vault_user_cap(vault, cap):

--- a/scripts/badger/guestlist.py
+++ b/scripts/badger/guestlist.py
@@ -20,10 +20,9 @@ def set_vault_user_cap(vault, cap):
     if guestlist != AddressZero:
         C.print(f"Guestlist: {guestlist}")
         SAFE.badger.set_guestlist_user_cap(guestlist, cap)
+        SAFE.post_safe_tx()
     else:
         C.print(f"[red]No guestlist set for this vault![/red]")
-
-    SAFE.post_safe_tx()
 
 # Sets a new total cap for a given vault
 def set_vault_total_cap(vault, cap):
@@ -32,10 +31,9 @@ def set_vault_total_cap(vault, cap):
     if guestlist != AddressZero:
         C.print(f"Guestlist: {guestlist}")
         SAFE.badger.set_guestlist_total_cap(guestlist, cap)
+        SAFE.post_safe_tx()
     else:
         C.print(f"[red]No guestlist set for this vault![/red]")
-
-    SAFE.post_safe_tx()
 
 # Sets the user and total cap to MAXUINT256 for a given vault
 def remove_caps_for_vault(vault):
@@ -45,10 +43,9 @@ def remove_caps_for_vault(vault):
         C.print(f"Guestlist: {guestlist}")
         SAFE.badger.set_guestlist_total_cap(guestlist, int(MaxUint256))
         SAFE.badger.set_guestlist_user_cap(guestlist, int(MaxUint256))
+        SAFE.post_safe_tx()
     else:
         C.print(f"[red]No guestlist set for this vault![/red]")
-
-    SAFE.post_safe_tx()
 
 # Sets the user and total cap to MAXUINT256 for a batch of vaults
 def remove_caps_for_vaults():
@@ -61,9 +58,8 @@ def remove_caps_for_vaults():
                 C.print(f"Guestlist: {guestlist}")
                 SAFE.badger.set_guestlist_total_cap(guestlist, int(MaxUint256))
                 SAFE.badger.set_guestlist_user_cap(guestlist, int(MaxUint256))
+                SAFE.post_safe_tx()
             else:
                 C.print(f"[red]No guestlist set for this vault ({vault})![/red]")
     else:
         C.print(f"[red]Make sure to add your vaults to the array![/red]")
-
-    SAFE.post_safe_tx()

--- a/scripts/badger/guestlist.py
+++ b/scripts/badger/guestlist.py
@@ -11,7 +11,7 @@ SAFE = GreatApeSafe(r.badger_wallets.techops_multisig)
 SAFE.init_badger()
 
 # Add the vaults addresses to remove caps from
-VAULTS_ARRAY = []
+VAULTS_ARRAY = ["0x63ad745506BD6a3E57F764409A47ed004BEc40b1", "0x371B7C451858bd88eAf392B383Df8bd7B8955d5a"]
 
 # Sets a new user cap for a given vault
 def set_vault_user_cap(vault, cap):
@@ -58,8 +58,8 @@ def remove_caps_for_vaults():
                 C.print(f"Guestlist: {guestlist}")
                 SAFE.badger.set_guestlist_total_cap(guestlist, int(MaxUint256))
                 SAFE.badger.set_guestlist_user_cap(guestlist, int(MaxUint256))
-                SAFE.post_safe_tx()
             else:
                 C.print(f"[red]No guestlist set for this vault ({vault})![/red]")
+        SAFE.post_safe_tx()
     else:
         C.print(f"[red]Make sure to add your vaults to the array![/red]")

--- a/scripts/badger/registry.py
+++ b/scripts/badger/registry.py
@@ -1,21 +1,22 @@
 from rich.console import Console
 from great_ape_safe import GreatApeSafe
+import click
 from helpers.addresses import get_registry as registry
 
 console = Console()
 
 # assuming techOps
-contract_registry = registry()
-chain_safe = GreatApeSafe(contract_registry.badger_wallets.techops_multisig)
-chain_safe.init_badger()
+r = registry()
+safe = GreatApeSafe(r.badger_wallets.techops_multisig)
+safe.init_badger()
 
 def set_key(key, target_addr):
     """
     Sets the input target address on the registry under the specified 'key' 
     """
 
-    chain_safe.badger.set_key_on_registry(key, target_addr)
-    chain_safe.post_safe_tx()
+    safe.badger.set_key_on_registry(key, target_addr)
+    safe.post_safe_tx()
 
 def migrate_registry_keys():
     """
@@ -28,8 +29,8 @@ def migrate_registry_keys():
     }
 
     key_lookups = {
-        'techOps': contract_registry.badger_wallets.techops_multisig,
-        'governanceTimelock': contract_registry.governance_timelock,
+        'techOps': r.badger_wallets.techops_multisig,
+        'governanceTimelock': r.governance_timelock,
     }
 
     key_set = set()
@@ -38,20 +39,20 @@ def migrate_registry_keys():
     while True:
         try:
             # # some registry keys are duplicated with surrounding quotes, let's remove and dedup
-            key = chain_safe.badger.registry.keys(key_index).replace("\"", "")
+            key = safe.badger.registry.keys(key_index).replace("\"", "")
 
             # ignore duplicated sanitized keys, only operate on unique values
             if key not in key_set:
                 should_replace = key in key_replacements
                 print(f"Migrating new unique key: {key} {'with' if should_replace else 'without'} replacement")
                 if should_replace:
-                    value = chain_safe.badger.registry.get(key)
+                    value = safe.badger.registry.get(key)
                     key = key_replacements[key]
                     if key in key_lookups:
                         value = key_lookups[key]
-                    chain_safe.badger.set_key_on_registry(key, value)
+                    safe.badger.set_key_on_registry(key, value)
                 else:
-                    chain_safe.badger.migrate_key_on_registry(key)
+                    safe.badger.migrate_key_on_registry(key)
 
                 key_set.add(key)
 
@@ -61,4 +62,47 @@ def migrate_registry_keys():
             break
 
     # try to simulate tx and see dafuq
-    chain_safe.post_safe_tx()
+    safe.post_safe_tx()
+
+
+
+# promote a batch of vaults given their addresses and new status
+def promote_vaults(vaults_array, new_status_array):
+    for vault in vaults_array:
+        info = safe.badger.registry_v2.productionVaultInfoByVault(vault)
+        new_status = new_status_array[vaults_array.index(vault)]
+        if info[2] < new_status:
+            safe.badger.promote_vault(info[0], info[1], info[3], new_status)
+            assert safe.badger.registry_v2.productionVaultInfoByVault(vault)[2] == new_status
+            console.print(f"[green]Promoting {vault} to {new_status}[/green]")
+        else:
+            console.print(f"[red]Promoting {vault} to lower state, current state is {info[2]}[/red]")
+    safe.post_safe_tx()
+
+
+
+# demote a batch of vaults given their addresses and new status
+def demote_vaults(vaults_array, new_status_array):
+    for vault in vaults_array:
+        info = safe.badger.registry_v2.productionVaultInfoByVault(vault)
+        new_status = new_status_array[vaults_array.index(vault)]
+        if info[2] < new_status:
+            safe.badger.demote_vault(vault, new_status)
+            assert safe.badger.registry_v2.productionVaultInfoByVault(vault)[2] == new_status
+            console.print(f"[green]Demoting {vault} to {new_status}[/green]")
+        else:
+            console.print(f"[red]Demoting to higher state, current state is {info[2]}[/red]")
+    safe.post_safe_tx()
+
+
+# interactive cli function that allows to change a vault's metadata with ease from options
+def update_vault_metadata(vault, metadata):
+    info = safe.badger.registry_v2.productionVaultInfoByVault(vault)
+    console.print(f"Current metadata: {info[3]}")
+    console.print(f"New metadata: {metadata}")
+
+    safe.badger.update_metadata(vault, metadata)
+    info = safe.badger.registry_v2.productionVaultInfoByVault(vault)
+    assert info[3] == metadata
+
+    safe.post_safe_tx()

--- a/scripts/badger/registry.py
+++ b/scripts/badger/registry.py
@@ -1,11 +1,10 @@
 from rich.console import Console
 from great_ape_safe import GreatApeSafe
-from helpers.addresses import get_registry as registry
+from helpers.addresses import r
 
 C = Console()
 
 # assuming techOps
-r = registry()
 SAFE = GreatApeSafe(r.badger_wallets.techops_multisig)
 SAFE.init_badger()
 


### PR DESCRIPTION
Tackles issue #757 

Introduces the following scripts to perform the following on the RegistryV2 and Guestlist with agility:

### RegistryV2
- Batch promote vaults from a list
- Batch demote vaults from a list
- Change metadata (the vault's behaviors allowed are limited to a list included in this PR - behaviors outside of this list are currently not being picked up by the UI's SDK).

### Guestlist
- Change the user cap of a given vault
- Change the total cap of a given vault
- Remove the caps for a given vault
- Remove the caps for a batch of vaults