### PR TITLE
feat: adapted sell weth script to check badger

### DIFF
--- a/scripts/badger/process_bribes_graviaura.py
+++ b/scripts/badger/process_bribes_graviaura.py
@@ -55,29 +55,13 @@ def claim_and_sell_for_weth():
             )
             PROCESSOR.sellBribeForWeth(order_payload, order_uid)
 
-        # If Badger is claimed, we store the amount to be able to pass it to next 
-        # step's script in order to estimate the Badger split to buy from WETH.
-        if addr == BADGER.address:
-            dump_dir = "data/badger/hh_badger_bribes/"
-            file_name = chain.time()
-            os.makedirs(dump_dir, exist_ok=True)
-            with open(f'{dump_dir}{file_name}.json', 'w') as f:
-                bribe_data = {
-                    'address': addr,
-                    'mantissa': mantissa,
-                    'timestamp': file_name
-                }
-                json.dump(bribe_data, f, indent=4, sort_keys=True)
-            print(f"Badger bribes claimed: {mantissa}")
-
     SAFE.post_safe_tx()
 
-# NOTE: If BADGER bribes were received, we pass the claimed amount to the script
-# in order to properly estimate the reminding amount of BADGER to be purchased.
-def sell_weth(badger_total="0"):
+
+def sell_weth():
     weth_total = WETH.balanceOf(PROCESSOR)
     aura_total = AURA.balanceOf(PROCESSOR)
-    badger_total = int(badger_total)
+    badger_total = BADGER.balanceOf(PROCESSOR)
 
     ## Estimate the amount of BADGER and AURA to buy
     # Grab prices from coingecko


### PR DESCRIPTION
Tackles issue #760 

With these changes, only the BADGER sent to the processor will be accounted towards HODLrs hunted bribes. For the time being, BADGER bribes will be redirected to Treasury so, unless someone manually sends BADGER to the processor, no BADGER will be transferred there from the strat. It is likely that the balance of BADGER on the processor will be 0 and 25% of the wETH will be sold for BADGER to compensate.