### PR TITLE
allow votes in different gauges in vote_proposal script

### DIFF
--- a/scripts/snapshot/AURA/vote_proposal.py
+++ b/scripts/snapshot/AURA/vote_proposal.py
@@ -1,15 +1,19 @@
 from great_ape_safe import GreatApeSafe
 from helpers.addresses import r
-
-
-GAUGE_TARGET = "80/20 BADGER/WBTC"
-VOTE_WEIGHT = 1 # 100%
+from enum import Enum
+ 
+ 
+class Gauges(Enum):
+    badger = {"80/20 BADGER/WBTC": 1}
+    digg = {"40/40/20 WBTC/DIGG/graviAURA": 1}
+    graviaura = {"33/33/33 graviAURA/auraBAL/WETH": 1}
 
 
 def main(
     proposal_id="0x515649bddfb0e0d637745e8654616b03b371bb444f90f327064e7eee6052aff8",
+    gauge="badger"
 ):
     voter = GreatApeSafe(r.badger_wallets.treasury_voter_multisig)
     voter.init_snapshot(proposal_id)
 
-    voter.snapshot.vote_and_post({GAUGE_TARGET: VOTE_WEIGHT})
+    voter.snapshot.vote_and_post(Gauges[gauge].value)


### PR DESCRIPTION
handles #787 `gauge` can now be passed into `vote_proposal.py` with the value corresponding to `Gauges` enum