### PR TITLE
Set AuraBribesProcessor pricer V3

### DIFF
--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -31,6 +31,7 @@ ADDRESSES_ETH = {
     "cvx_bribes_processor": "0xb2Bf1d48F2C2132913278672e6924efda3385de2",
     "aura_bribes_processor": "0x8ABD28E4D69bD3953b96dd9ED63533765AdB9965",
     "digg_monetary_policy": "0x327a78D13eA74145cc0C63E6133D516ad3E974c3",
+    "on_chain_pricing_mainnet_lenient": "0x2DC7693444aCd1EcA1D6dE5B3d0d8584F3870c49",
     # the wallets listed here are looped over by scout and checked for all treasury tokens
     "badger_wallets": {
         "fees": "0x8dE82C4C968663a0284b01069DDE6EF231D0Ef9B",

--- a/scripts/issue/797/set_pricer_on_processor.py
+++ b/scripts/issue/797/set_pricer_on_processor.py
@@ -1,0 +1,54 @@
+from brownie import interface, accounts
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import registry
+from rich.console import Console
+
+C = Console()
+
+DEV = registry.eth.badger_wallets.dev_multisig
+PROCESSOR = registry.eth.aura_bribes_processor
+PRICER = registry.eth.on_chain_pricing_mainnet_lenient
+
+# Simulation
+COEF = 0.9825
+DEADLINE = 60 * 60 * 3
+BRIBE_TOKEN = registry.eth.bribe_tokens_claimable_graviaura.DFX
+WHALE = "0xA4fc358455Febe425536fd1878bE67FfDBDEC59a"
+AMOUNT = 1000e18
+
+def main(simulation="false"):
+    safe = GreatApeSafe(DEV)
+    safe.init_badger()
+
+    processor = safe.contract(PROCESSOR)
+
+    processor.setPricer(PRICER)
+    assert processor.pricer() == PRICER
+
+    # Simulate 
+    if simulation == "true":
+        weth = interface.IWETH9(registry.eth.treasury_tokens.WETH, owner=safe.account)
+        whale = accounts.at(WHALE, force=True)
+        token = safe.contract(BRIBE_TOKEN)
+        settlement = safe.contract(processor.SETTLEMENT())
+
+        token.transfer(PROCESSOR, AMOUNT, {"from": whale})
+        assert token.balanceOf(PROCESSOR) == AMOUNT
+
+        safe.init_badger()
+        safe.init_cow(prod=False)
+
+        order_payload, order_uid = safe.badger.get_order_for_processor(
+            processor,
+            sell_token=token,
+            mantissa_sell=AMOUNT,
+            buy_token=weth,
+            deadline=DEADLINE,
+            coef=COEF,
+            prod=False,
+        )
+        processor.sellBribeForWeth(order_payload, order_uid, {"from": accounts.at(processor.manager(), force=True)})
+
+        assert settlement.preSignature(order_uid) > 0
+
+    safe.post_safe_tx()


### PR DESCRIPTION
Tackles issue #797 

Sets a new pricer on the AuraBribesProcessor from devMulti. 

NOTE: Didn't add as generic script in order to incorporate a simulation - this shouldn't be an action that we perform often.

Run with:
```
brownie run scripts/issue/797/set_pricer_on_processor.py
```

Simulate with: 
```
brownie run scripts/issue/797/set_pricer_on_processor.py main true
```