### PR TITLE
Aura gauges migration script

### DIFF
--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -316,7 +316,8 @@ ADDRESSES_ETH = {
         "native.bcrvBadger": "0x1905FD2D2D09792eE058C2b46a05F11630a1EcA1",
         "native.graviAURA": "0x3c0989eF27e3e3fAb87a2d7C38B35880C90E63b5",
         "native.bauraBal": "0x32BdF2B35Bbf8dAca3561C3ADE59c941488E9c69",
-        "native.b80BADGER-20WBTC": "0xe43857fE16D18b6633A663389934d6c64D5E81FD",
+        "native.b80BADGER_20WBTC": "0xe43857fE16D18b6633A663389934d6c64D5E81FD",
+        "native.b40WBTC_40DIGG_20graviAURA": "0xD87F2cdE238D0122b3865164359CFF6b2431d927",
         "_deprecated": {
             "native.bauraBal": {
                 "v1": "0xfB490b5beA343ABAe0E71B61bBdfd4301F5e4df9",

--- a/interfaces/badger/IStrategyAuraStaking.sol
+++ b/interfaces/badger/IStrategyAuraStaking.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
+pragma experimental ABIEncoderV2;
+
+import {BaseStrategy} from "./IVestedAura.sol";
+
+interface IStrategyAuraStaking {
+    event Paused(address account);
+    event SetWithdrawalMaxDeviationThreshold(uint256 newMaxDeviationThreshold);
+    event Unpaused(address account);
+
+    function AURA() external view returns (address);
+
+    function AURABAL() external view returns (address);
+
+    function AURABAL_BALETH_BPT_POOL_ID() external view returns (bytes32);
+
+    function BAL() external view returns (address);
+
+    function BALANCER_VAULT() external view returns (address);
+
+    function BALETH_BPT() external view returns (address);
+
+    function BAL_ETH_POOL_ID() external view returns (bytes32);
+
+    function BAURABAL() external view returns (address);
+
+    function BOOSTER() external view returns (address);
+
+    function GRAVIAURA() external view returns (address);
+
+    function MAX_BPS() external view returns (uint256);
+
+    function WETH() external view returns (address);
+
+    function __BaseStrategy_init(address _vault) external;
+
+    function autoCompoundRatio() external view returns (uint256);
+
+    function balEthBptToAuraBalMinOutBps() external view returns (uint256);
+
+    function balanceOf() external view returns (uint256);
+
+    function balanceOfPool() external view returns (uint256);
+
+    function balanceOfRewards()
+        external
+        view
+        returns (BaseStrategy.TokenAmount[] memory rewards);
+
+    function balanceOfWant() external view returns (uint256);
+
+    function baseRewardPool() external view returns (address);
+
+    function baseStrategyVersion() external pure returns (string memory);
+
+    function claimRewardsOnWithdrawAll() external view returns (bool);
+
+    function deposit() external;
+
+    function earn() external;
+
+    function emitNonProtectedToken(address _token) external;
+
+    function getMintableAuraRewards(uint256 _balAmount)
+        external
+        view
+        returns (uint256 amount);
+
+    function getName() external pure returns (string memory);
+
+    function getProtectedTokens() external view returns (address[] memory);
+
+    function governance() external view returns (address);
+
+    function guardian() external view returns (address);
+
+    function harvest()
+        external
+        returns (BaseStrategy.TokenAmount[] memory harvested);
+
+    function initialize(address _vault, uint256 _pid) external;
+
+    function isProtectedToken(address token) external view returns (bool);
+
+    function isTendable() external pure returns (bool);
+
+    function keeper() external view returns (address);
+
+    function pause() external;
+
+    function paused() external view returns (bool);
+
+    function pid() external view returns (uint256);
+
+    function setBalEthBptToAuraBalMinOutBps(uint256 _minOutBps) external;
+
+    function setClaimRewardsOnWithdrawAll(bool _claimRewardsOnWithdrawAll)
+        external;
+
+    function setPid(uint256 _pid) external;
+
+    function setWithdrawalMaxDeviationThreshold(uint256 _threshold) external;
+
+    function strategist() external view returns (address);
+
+    function tend() external returns (BaseStrategy.TokenAmount[] memory tended);
+
+    function unpause() external;
+
+    function vault() external view returns (address);
+
+    function want() external view returns (address);
+
+    function withdraw(uint256 _amount) external;
+
+    function withdrawOther(address _asset) external;
+
+    function withdrawToVault() external;
+
+    function withdrawalMaxDeviationThreshold() external view returns (uint256);
+}

--- a/scripts/issue/823/migrate_strategy_gauges.py
+++ b/scripts/issue/823/migrate_strategy_gauges.py
@@ -1,0 +1,87 @@
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import r
+from rich.console import Console
+from brownie import interface
+
+C = Console()
+
+VAULTS_PIDS = {
+    "b80BADGER_20WBTC": 33,
+    # "b40WBTC_40DIGG_20graviAURA": 34,
+}
+
+def main():
+    safe = GreatApeSafe(r.badger_wallets.dev_multisig)
+    booster = safe.contract(r.aura.booster)
+
+    for vault_id, pid in VAULTS_PIDS.items():
+        vault = safe.contract(r.sett_vaults[vault_id])
+        strat = interface.IStrategyAuraStaking(vault.strategy(), owner=safe.account)
+        want = safe.contract(vault.token())
+
+        C.print(f"[cyan]Migrating gauge for {vault.name()}[/cyan]")
+
+        #### 1. Harvest strategy ####
+        strat.harvest()
+
+        #### 2. Withdraw all to vault ####
+        vault_balance_before = want.balanceOf(vault.address)
+        pool_balance_before = strat.balanceOfPool()
+        strat_balance_before = strat.balanceOfWant()
+        total_balance_before = vault.balance()
+        assert total_balance_before == vault_balance_before + pool_balance_before + strat_balance_before
+
+        # Call withdrawToVault
+        vault.withdrawToVault()
+
+        # Confrm balances
+        assert want.balanceOf(vault.address) == total_balance_before
+        assert strat.balanceOfPool() == 0
+
+        #### 3. set new PID ####
+        pid_before = strat.pid()
+        baseRewardPool_before = strat.baseRewardPool()
+
+        # Confirm new PIDs info
+        old_info = booster.poolInfo(pid_before)
+        new_info = booster.poolInfo(pid)
+        baseRewardPool_new = new_info["crvRewards"]
+        gauge_new = new_info["gauge"]
+        assert old_info["lptoken"] == want.address
+        assert old_info["lptoken"] == new_info["lptoken"]
+        assert baseRewardPool_before != baseRewardPool_new
+
+        # Set new PID
+        strat.setPid(pid)
+
+        assert strat.pid() == pid
+        assert strat.baseRewardPool() == baseRewardPool_new
+
+        #### 4. Earn ####
+        # Ensure that we are not the first ones to deposit on the new gauge
+        new_deposit_token = safe.contract(new_info["token"])
+        rewards_d_tkn_balance_before = new_deposit_token.balanceOf(baseRewardPool_new)
+        assert rewards_d_tkn_balance_before > 0
+
+        gauge_balance_before = want.balanceOf(gauge_new)
+        available = vault.available()
+
+        vault.earn()
+
+        # Check that assets move properly
+        gauge_balance_after= want.balanceOf(gauge_new)
+        rewards_d_tkn_balance_after = new_deposit_token.balanceOf(baseRewardPool_new)
+        assert available == gauge_balance_after - gauge_balance_before
+        assert available == strat.balanceOfPool()
+        assert available == rewards_d_tkn_balance_after - rewards_d_tkn_balance_before
+        # Assert that the total amount of tokens remained the same
+        assert total_balance_before == vault.balance()
+
+        C.print(f"[green]Migration successful![/green]")
+
+    safe.post_safe_tx()
+
+
+
+
+        

--- a/scripts/issue/823/migrate_strategy_gauges.py
+++ b/scripts/issue/823/migrate_strategy_gauges.py
@@ -7,7 +7,7 @@ C = Console()
 
 VAULTS_PIDS = {
     "b80BADGER_20WBTC": 33,
-    # "b40WBTC_40DIGG_20graviAURA": 34,
+    "b40WBTC_40DIGG_20graviAURA": 34,
 }
 
 def main():

--- a/scripts/issue/823/migrate_strategy_gauges.py
+++ b/scripts/issue/823/migrate_strategy_gauges.py
@@ -116,8 +116,3 @@ def main(simulation="false"):
 
     if simulation == "false":
         safe.post_safe_tx()
-
-
-
-
-        

--- a/scripts/issue/823/migrate_strategy_gauges.py
+++ b/scripts/issue/823/migrate_strategy_gauges.py
@@ -1,7 +1,7 @@
 from great_ape_safe import GreatApeSafe
 from helpers.addresses import r
 from rich.console import Console
-from brownie import interface
+from brownie import interface, chain, accounts
 
 C = Console()
 
@@ -10,7 +10,12 @@ VAULTS_PIDS = {
     "b40WBTC_40DIGG_20graviAURA": 34,
 }
 
-def main():
+USER = accounts.at("0x53D8EDF6a54239eB785eC72213919Fb6b6B73598", force=True)
+
+BAURABAL = r.sett_vaults.bauraBal
+GRAVIAURA = r.sett_vaults.graviAURA
+
+def main(simulation="false"):
     safe = GreatApeSafe(r.badger_wallets.dev_multisig)
     booster = safe.contract(r.aura.booster)
 
@@ -24,11 +29,17 @@ def main():
         #### 1. Harvest strategy ####
         strat.harvest()
 
+        # There are no more pending rewards
+        pending_rewards = strat.balanceOfRewards()
+        assert pending_rewards[0][1] == 0
+        assert pending_rewards[1][1] == 0
+
         #### 2. Withdraw all to vault ####
         vault_balance_before = want.balanceOf(vault.address)
         pool_balance_before = strat.balanceOfPool()
         strat_balance_before = strat.balanceOfWant()
         total_balance_before = vault.balance()
+        ppfs_before = vault.getPricePerFullShare()
         assert total_balance_before == vault_balance_before + pool_balance_before + strat_balance_before
 
         # Call withdrawToVault
@@ -76,10 +87,35 @@ def main():
         assert available == rewards_d_tkn_balance_after - rewards_d_tkn_balance_before
         # Assert that the total amount of tokens remained the same
         assert total_balance_before == vault.balance()
+        # Ppfs shouldn't change if balance doesn't change but why not
+        assert vault.getPricePerFullShare() == ppfs_before
 
         C.print(f"[green]Migration successful![/green]")
 
-    safe.post_safe_tx()
+        if simulation == "true":
+            # Snapshotting to ensure both simulations run at the same time
+            chain.snapshot()
+            chain.sleep(3*24*3600)
+
+            # Can properly harvest
+            tx = strat.harvest()
+            events = tx.events
+            # Emits bauraBAL and graviAURA
+            assert len(events["TreeDistribution"]) == 2
+            assert events["TreeDistribution"][0]["token"] == BAURABAL
+            assert events["TreeDistribution"][0]["amount"] > 0
+            assert events["TreeDistribution"][1]["token"] == GRAVIAURA
+            assert events["TreeDistribution"][1]["amount"] > 0
+
+            # Can properly withdraw
+            user_balance_before = want.balanceOf(USER)
+            vault.withdrawAll({"from": USER})
+            assert want.balanceOf(USER) > user_balance_before
+
+            chain.revert()
+
+    if simulation == "false":
+        safe.post_safe_tx()
 
 
 


### PR DESCRIPTION
Tackles issue #823 

Script that migrates the underlying gauge of Aura strategies to a new one based on the Aura's PID for that gauge.

NOTE: The script will prevent the gauge migration if it finds the new base rewards pool to empty. As per @GalloDaSballo, "We need more than 1e18 ppfs to avoid a rebase of the ppfs over time".

Run with:
```
brownie run scripts/issue/823/migrate_strategy_gauges.py
```

Run simulation with:
```
brownie run scripts/issue/823/migrate_strategy_gauges.py main true
```