### PR TITLE
Adapted Vaults v1.5 upgrade script to include fee events

### DIFF
--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -284,6 +284,8 @@ ADDRESSES_ETH = {
         "b40WBTC_40DIGG_20graviAURA": "0x371B7C451858bd88eAf392B383Df8bd7B8955d5a",
         "bBB_a_USD": "0x06D756861De0724FAd5B5636124e0f252d3C1404",
         "b33auraBAL_33graviAURA_33WETH": "0xf8f5677B6bCecdb9be94AE8f6770a05a6C53C378",
+        "bB_stETH_STABLE": "0x41466b8ec544e3192Aa1aA30f65fC60FAb4D52Bf",
+        "bB-rETH-STABLE": "0xA484427CF91bbd945c39eF87dF0A02Bb8625dC97"
     },
     "strategies": {
         "native.badger": "0x75b8E21BD623012Efb3b69E1B562465A68944eE6",
@@ -317,6 +319,8 @@ ADDRESSES_ETH = {
         "native.graviAURA": "0x3c0989eF27e3e3fAb87a2d7C38B35880C90E63b5",
         "native.bauraBal": "0x32BdF2B35Bbf8dAca3561C3ADE59c941488E9c69",
         "native.b80BADGER-20WBTC": "0xe43857fE16D18b6633A663389934d6c64D5E81FD",
+        "native.bB_stETH_STABLE": "0x1cC3731d8f30341EF4527E7da1B6a4DA88ef71DF",
+        "native.bB-rETH-STABLE": "0xE6153AdD9913c7D25a6d475acFfACc5Eb570D8bE",
         "_deprecated": {
             "native.bauraBal": {
                 "v1": "0xfB490b5beA343ABAe0E71B61bBdfd4301F5e4df9",
@@ -349,7 +353,7 @@ ADDRESSES_ETH = {
         "BadgerSettPeak": "0x56bb91BfbeEB5400db72bcE4c15eb0Ddfd06002C",  # V1.1
         "uFragments": "0x020eb84309243Ed4B8E6C197AF145125dDE4AFDa",  # V1.1
         "SimpleWrapperGatedUpgradeable": "0x021ea7548Ee9B40d57f47706A605043B05C6c92C",
-        "TheVault": "0x55918A84eB7Fd1D930e098a8E86D0206549fA8c3",
+        "TheVault": "0x60c796ACb2E0949178086294f03A44C450511784", # V1.5.2.a
     },
     "guestlists": {
         "bimBTC": "0x7feCCc72aE222e0483cBDE212F5F88De62132546",

--- a/scripts/issue/799/upgrade_vaults_v1_5.py
+++ b/scripts/issue/799/upgrade_vaults_v1_5.py
@@ -13,21 +13,25 @@ NEW_LOGIC = registry.eth.logic.TheVault
 DEV_PROXY = registry.eth.badger_wallets.devProxyAdmin
 
 KEYS = [
-    "graviAURA",
-    "bauraBal",
-    "b80BADGER_20WBTC",
+    # "graviAURA",
+    # "bauraBal",
+    # "b80BADGER_20WBTC",
     "b40WBTC_40DIGG_20graviAURA",
     "bBB_a_USD",
-    "b33auraBAL_33graviAURA_33WETH"
+    "b33auraBAL_33graviAURA_33WETH",
+    "bB_stETH_STABLE",
+    "bB-rETH-STABLE"
 ]
 
 HODLERS = [
-    "0xD14f076044414C255D2E82cceB1CB00fb1bBA64c",
-    "0xfe51263bd0d075dc5441e89ecd1f6d63ff41e02e",
-    "0xec4fcd1aca723f8456999c5f5d7479dbe9528c11",
-    "0x3cd3dba355776ac76a0485e728ead54092085da2",
+    # "0xD14f076044414C255D2E82cceB1CB00fb1bBA64c",
+    # "0xfe51263bd0d075dc5441e89ecd1f6d63ff41e02e",
+    # "0xec4fcd1aca723f8456999c5f5d7479dbe9528c11",
+    "0x95eec544a7cf2e6a65a71039d58823f4564a6319",
     "0xc3b1f7ab9fabd729cdf9e90ea54ec447f9464269",
-    "0x794783dcfcac8c1944727057a3208d8f8bb91506"
+    "0x794783dcfcac8c1944727057a3208d8f8bb91506",
+    "0xee8b29aa52dd5ff2559da2c50b1887adee257556",
+    "0xee8b29aa52dd5ff2559da2c50b1887adee257556"
 ]
 
 
@@ -46,13 +50,13 @@ def main(queue="true", simulation="false"):
                         ["address", "address"],
                         [address, NEW_LOGIC],
                     ),
-                    dump_dir="data/badger/timelock/upgrade_vaults_v1_5_fee_events/",
+                    dump_dir="data/badger/timelock/upgrade_vaults_v1_5_2a_fee_events/",
                     delay_in_days=4,
                 )
             else:
                 execute_timelock(
                     safe.badger.timelock,
-                    "data/badger/timelock/upgrade_vaults_v1_5_fee_events/",
+                    "data/badger/timelock/upgrade_vaults_v1_5_2a_fee_events/",
                     key,
                     address,
                     simulation,
@@ -144,10 +148,10 @@ def execute_timelock(timelock, queueTx_dir, key, address, simulation, safe):
         # New event triggers
         assert len(tx.events["PerformanceFeeGovernance"]) >= 1
 
-        # Simulate a withdrawal (small amount to keep it simple)
+        # Simulate a withdrawal
         if vault.withdrawalFee() > 0:
             hodler = accounts.at(HODLERS[KEYS.index(key)], force=True)
-            tx = vault.withdraw(1e17, {"from": hodler})
+            tx = vault.withdrawAll({"from": hodler})
             # New event triggers
             assert len(tx.events["WithdrawalFee"]) >= 1
 


### PR DESCRIPTION
Tackles issue #799 

Queue with:
```
brownie run scripts/issue/799/upgrade_vaults_v1_5.py
```
Execute with:
```
brownie run scripts/issue/799/upgrade_vaults_v1_5.py main true
```
Simulate with:
```
brownie run scripts/issue/799/upgrade_vaults_v1_5.py main false true
```
