### PR TITLE
Stake curve badgerfraxbp in frax gauge via private vault

### DIFF
--- a/great_ape_safe/ape_api/convex.py
+++ b/great_ape_safe/ape_api/convex.py
@@ -6,7 +6,6 @@ from helpers.addresses import registry
 # dictionary holding the different frax vault pids
 VAULT_TYPES = {
     "VAFRAX": 0,
-    "VAFRAX": 0,
     "UNIV2_TEMPLE": 1,
     "AFRAX": 2,
     "CURVE_LP": 3,

--- a/great_ape_safe/ape_api/convex.py
+++ b/great_ape_safe/ape_api/convex.py
@@ -25,7 +25,14 @@ class Convex:
         # frax contract section
         self.frax_booster = safe.contract(registry.eth.convex.frax.booster)
         self.frax_pool_registry = safe.contract(registry.eth.convex.frax.pool_registry)
-        self.VAULT_TYPES = VAULT_TYPES
+        # dictionary holding the different frax vault pids
+        self.VAULT_TYPES = {
+            "vafrax": 0,
+            "univ2_temple": 1,
+            "afrax": 2,
+            "curve_lp": 3,
+            "badger_fraxbp": 35,
+        }
 
     def get_pool_info(self, underlying):
         # return pool id, cvx_token and gauge address for `underlying`

--- a/great_ape_safe/ape_api/convex.py
+++ b/great_ape_safe/ape_api/convex.py
@@ -8,6 +8,7 @@ class VaultTypes:
     UNIV2_TEMPLE = 1
     AFRAX = 2
     CURVE_LP = 3
+    BADGER_FRAXBP = 33
 
 
 class Convex:
@@ -192,7 +193,7 @@ class Convex:
     def stake_lock(self, staking_token, mantissa, seconds):
         pid = self.get_pool_pid(staking_token)
 
-        if pid == VaultTypes.AFRAX:
+        if pid in [VaultTypes.AFRAX, VaultTypes.BADGER_FRAXBP]:
             staking_proxy = self.safe.contract(self.get_vault(staking_token))
             staking_contract = self.safe.contract(staking_proxy.stakingAddress())
             staking_token.approve(staking_proxy, mantissa)

--- a/great_ape_safe/ape_api/convex.py
+++ b/great_ape_safe/ape_api/convex.py
@@ -197,7 +197,7 @@ class Convex:
         if not pid:
             pid = self.get_pool_pid(staking_token)
 
-        if pid in [VaultTypes.AFRAX, VaultTypes.BADGER_FRAXBP]:
+        if pid in [self.VAULT_TYPES["afrax"], self.VAULT_TYPES["badger_fraxbp"]]:
             staking_proxy = self.safe.contract(self.get_vault(pid))
             staking_contract = self.safe.contract(staking_proxy.stakingAddress())
             staking_token.approve(staking_proxy, mantissa)

--- a/great_ape_safe/ape_api/convex.py
+++ b/great_ape_safe/ape_api/convex.py
@@ -3,12 +3,15 @@ from brownie import interface
 from helpers.addresses import registry
 
 
-class VaultTypes:
-    VAFRAX = 0
-    UNIV2_TEMPLE = 1
-    AFRAX = 2
-    CURVE_LP = 3
-    BADGER_FRAXBP = 35
+# dictionary holding the different frax vault pids
+VAULT_TYPES = {
+    "VAFRAX": 0,
+    "VAFRAX": 0,
+    "UNIV2_TEMPLE": 1,
+    "AFRAX": 2,
+    "CURVE_LP": 3,
+    "BADGER_FRAXBP": 35,
+}
 
 
 class Convex:
@@ -33,6 +36,7 @@ class Convex:
         # frax contract section
         self.frax_booster = safe.contract(registry.eth.convex.frax.booster)
         self.frax_pool_registry = safe.contract(registry.eth.convex.frax.pool_registry)
+        self.VAULT_TYPES = VAULT_TYPES
 
     def get_pool_info(self, underlying):
         # return pool id, cvx_token and gauge address for `underlying`
@@ -65,7 +69,7 @@ class Convex:
         # https://docs.convexfinance.com/convexfinanceintegration/booster#deposits
         stake = 0
         pool_id = self.get_pool_info(underlying)[0]
-        underlying.approve(self.booster, 2**256 - 1)
+        underlying.approve(self.booster, 2 ** 256 - 1)
         assert self.booster.depositAll(pool_id, stake).return_value == True
         underlying.approve(self.booster, 0)
 
@@ -75,7 +79,7 @@ class Convex:
         # https://docs.convexfinance.com/convexfinanceintegration/booster#deposits
         stake = 1
         pool_id = self.get_pool_info(underlying)[0]
-        underlying.approve(self.booster, 2**256 - 1)
+        underlying.approve(self.booster, 2 ** 256 - 1)
         assert self.booster.depositAll(pool_id, stake).return_value == True
         underlying.approve(self.booster, 0)
 
@@ -127,7 +131,7 @@ class Convex:
         # stake complete balance of `underlying`'s corresponding convex tokens
         # https://docs.convexfinance.com/convexfinanceintegration/baserewardpool#stake-deposit-tokens
         _, cvx_token, _, rewards = self.get_pool_info(underlying)
-        self.safe.contract(cvx_token).approve(rewards, 2**256 - 1)
+        self.safe.contract(cvx_token).approve(rewards, 2 ** 256 - 1)
         assert self.safe.contract(rewards).stakeAll().return_value == True
         self.safe.contract(cvx_token).approve(rewards, 0)
 

--- a/great_ape_safe/ape_api/convex.py
+++ b/great_ape_safe/ape_api/convex.py
@@ -184,8 +184,9 @@ class Convex:
 
         return self.frax_pool_registry.vaultMap(pid, owner)
 
-    def create_vault(self, staking_token):
-        pid = self.get_pool_pid(staking_token)
+    def create_vault(self, staking_token, pid=None):
+        if not pid:
+            pid = self.get_pool_pid(staking_token)
         # internally happens the approval of the staking_token for the staking_address
         # ref: https://github.com/convex-eth/frax-cvx-platform/blob/main/contracts/contracts/StakingProxyERC20.sol#L34
         self.frax_booster.createVault(pid)

--- a/great_ape_safe/ape_api/convex.py
+++ b/great_ape_safe/ape_api/convex.py
@@ -3,16 +3,6 @@ from brownie import interface
 from helpers.addresses import registry
 
 
-# dictionary holding the different frax vault pids
-VAULT_TYPES = {
-    "VAFRAX": 0,
-    "UNIV2_TEMPLE": 1,
-    "AFRAX": 2,
-    "CURVE_LP": 3,
-    "BADGER_FRAXBP": 35,
-}
-
-
 class Convex:
     def __init__(self, safe):
         self.safe = safe

--- a/great_ape_safe/ape_api/convex.py
+++ b/great_ape_safe/ape_api/convex.py
@@ -223,7 +223,7 @@ class Convex:
         if not pid:
             pid = self.get_pool_pid(staking_token)
 
-        if pid == [VaultTypes.AFRAX, VaultTypes.BADGER_FRAXBP]:
+        if pid in [self.VAULT_TYPES["afrax"], self.VAULT_TYPES["badger_fraxbp"]]:
             staking_proxy = self.safe.contract(self.get_vault(pid))
             staking_contract = self.safe.contract(staking_proxy.stakingAddress())
 

--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -458,7 +458,7 @@ ADDRESSES_ETH = {
         "frax": {
             "booster": "0xEe3Ab4e439ed52C7B8668864e2452ed23a9D67e8",
             "pool_registry": "0x41a5881c17185383e19Df6FA4EC158a6F4851A69",
-            "stk_badger_fraxbp": "0xb92e3fD365Fc5E038aa304Afe919FeE158359C88",
+            "wcvx_badger_fraxbp": "0xb92e3fD365Fc5E038aa304Afe919FeE158359C88",
         },
     },
     "votium": {

--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -458,6 +458,7 @@ ADDRESSES_ETH = {
         "frax": {
             "booster": "0xEe3Ab4e439ed52C7B8668864e2452ed23a9D67e8",
             "pool_registry": "0x41a5881c17185383e19Df6FA4EC158a6F4851A69",
+            "stk_badger_fraxbp": "0xb92e3fD365Fc5E038aa304Afe919FeE158359C88",
         },
     },
     "votium": {

--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -456,7 +456,7 @@ ADDRESSES_ETH = {
         "claim_zap": "0x92Cf9E5e4D1Dfbf7dA0d2BB3e884a68416a65070",
         "vlCVX": "0xD18140b4B819b895A3dba5442F959fA44994AF50",
         "frax": {
-            "booster": "0xEe3Ab4e439ed52C7B8668864e2452ed23a9D67e8",
+            "booster": "0x569f5B842B5006eC17Be02B8b94510BA8e79FbCa",
             "pool_registry": "0x41a5881c17185383e19Df6FA4EC158a6F4851A69",
             "wcvx_badger_fraxbp": "0xb92e3fD365Fc5E038aa304Afe919FeE158359C88",
         },

--- a/scripts/issue/930/frax_stake_badgerfraxbp.py
+++ b/scripts/issue/930/frax_stake_badgerfraxbp.py
@@ -13,7 +13,7 @@ wcvx_badger_fraxbp = vault.contract(r.convex.frax.wcvx_badger_fraxbp)
 def create_vault():
     vault.init_convex()
     vault.convex.create_vault(
-        wcvx_badger_fraxbp, vault.convex.VAULT_TYPES["BADGER_FRAXBP"]
+        wcvx_badger_fraxbp, vault.convex.VAULT_TYPES["badger_fraxbp"]
     )
 
     vault.post_safe_tx()
@@ -40,7 +40,7 @@ def stake_in_vault():
         wcvx_badger_fraxbp,
         staking_lp_balance,
         MIN_LOCK_TIME,
-        vault.convex.VAULT_TYPES["BADGER_FRAXBP"],
+        vault.convex.VAULT_TYPES["badger_fraxbp"],
     )
 
     vault.post_safe_tx()

--- a/scripts/issue/930/frax_stake_badgerfraxbp.py
+++ b/scripts/issue/930/frax_stake_badgerfraxbp.py
@@ -4,6 +4,9 @@ from helpers.addresses import r
 # https://etherscan.io/address/0x5a92EF27f4baA7C766aee6d751f754EBdEBd9fae#code#L722
 MIN_LOCK_TIME = 594000
 
+# https://etherscan.io/tx/0x926d29b92b4b1b2deef70e54e41d4478106eb8062a59ea58c74f628892c05710#eventlog
+PID = 35
+
 vault = GreatApeSafe(r.badger_wallets.treasury_vault_multisig)
 
 badger_fraxbp = vault.contract(r.treasury_tokens.badgerFRAXBP_f_lp)
@@ -12,8 +15,7 @@ stkcvx_badger_fraxbp = vault.contract(r.convex.frax.stk_badger_fraxbp)
 
 def create_vault():
     vault.init_convex()
-    # https://etherscan.io/tx/0x4895666dd53a4a6bb00611ee27e846653a2927b0a675a56202ca527e827c3e33#eventlog
-    vault.convex.create_vault(stkcvx_badger_fraxbp)
+    vault.convex.create_vault(stkcvx_badger_fraxbp, PID)
 
     vault.post_safe_tx()
 

--- a/scripts/issue/930/frax_stake_badgerfraxbp.py
+++ b/scripts/issue/930/frax_stake_badgerfraxbp.py
@@ -37,6 +37,6 @@ def stake_in_vault():
     assert staking_lp_balance == lp_balance
 
     # 3. lock in the vault
-    vault.convex.stake_lock(stkcvx_badger_fraxbp, staking_lp_balance, MIN_LOCK_TIME)
+    vault.convex.stake_lock(stkcvx_badger_fraxbp, staking_lp_balance, MIN_LOCK_TIME, PID)
 
     vault.post_safe_tx()

--- a/scripts/issue/930/frax_stake_badgerfraxbp.py
+++ b/scripts/issue/930/frax_stake_badgerfraxbp.py
@@ -1,0 +1,40 @@
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import r
+
+# https://etherscan.io/address/0x5a92EF27f4baA7C766aee6d751f754EBdEBd9fae#code#L722
+MIN_LOCK_TIME = 594000
+
+vault = GreatApeSafe(r.badger_wallets.treasury_vault_multisig)
+
+badger_fraxbp = vault.contract(r.treasury_tokens.badgerFRAXBP_f_lp)
+stkcvx_badger_fraxbp = vault.contract(r.convex.frax.stk_badger_fraxbp)
+
+
+def create_vault():
+    vault.init_convex()
+    # https://etherscan.io/tx/0x4895666dd53a4a6bb00611ee27e846653a2927b0a675a56202ca527e827c3e33#eventlog
+    vault.convex.create_vault(stkcvx_badger_fraxbp)
+
+    vault.post_safe_tx()
+
+
+def stake_in_vault():
+    vault.init_convex()
+
+    # 1. unstake and claim rewards from vanilla convex
+    vault.convex.unstake_all_and_withdraw_all(badger_fraxbp, claim=1)
+
+    # 2. deposit in convex staking frax wrapper
+    lp_balance = badger_fraxbp.balanceOf(vault)
+    badger_fraxbp.approve(stkcvx_badger_fraxbp, lp_balance)
+    # https://etherscan.io/address/0xb92e3fD365Fc5E038aa304Afe919FeE158359C88#code#L1397
+    stkcvx_badger_fraxbp.deposit(lp_balance, vault)
+
+    # ratio of staking version should be 1:1
+    staking_lp_balance = stkcvx_badger_fraxbp.balanceOf(vault)
+    assert staking_lp_balance == lp_balance
+
+    # 3. lock in the vault
+    vault.convex.stake_lock(stkcvx_badger_fraxbp, staking_lp_balance, MIN_LOCK_TIME)
+
+    vault.post_safe_tx()

--- a/scripts/issue/930/frax_stake_badgerfraxbp.py
+++ b/scripts/issue/930/frax_stake_badgerfraxbp.py
@@ -4,18 +4,17 @@ from helpers.addresses import r
 # https://etherscan.io/address/0x5a92EF27f4baA7C766aee6d751f754EBdEBd9fae#code#L722
 MIN_LOCK_TIME = 594000
 
-# https://etherscan.io/tx/0x926d29b92b4b1b2deef70e54e41d4478106eb8062a59ea58c74f628892c05710#eventlog
-PID = 35
-
 vault = GreatApeSafe(r.badger_wallets.treasury_vault_multisig)
 
 badger_fraxbp = vault.contract(r.treasury_tokens.badgerFRAXBP_f_lp)
-stkcvx_badger_fraxbp = vault.contract(r.convex.frax.stk_badger_fraxbp)
+wcvx_badger_fraxbp = vault.contract(r.convex.frax.wcvx_badger_fraxbp)
 
 
 def create_vault():
     vault.init_convex()
-    vault.convex.create_vault(stkcvx_badger_fraxbp, PID)
+    vault.convex.create_vault(
+        wcvx_badger_fraxbp, vault.convex.VAULT_TYPES["BADGER_FRAXBP"]
+    )
 
     vault.post_safe_tx()
 
@@ -28,15 +27,20 @@ def stake_in_vault():
 
     # 2. deposit in convex staking frax wrapper
     lp_balance = badger_fraxbp.balanceOf(vault)
-    badger_fraxbp.approve(stkcvx_badger_fraxbp, lp_balance)
+    badger_fraxbp.approve(wcvx_badger_fraxbp, lp_balance)
     # https://etherscan.io/address/0xb92e3fD365Fc5E038aa304Afe919FeE158359C88#code#L1397
-    stkcvx_badger_fraxbp.deposit(lp_balance, vault)
+    wcvx_badger_fraxbp.deposit(lp_balance, vault)
 
     # ratio of staking version should be 1:1
-    staking_lp_balance = stkcvx_badger_fraxbp.balanceOf(vault)
+    staking_lp_balance = wcvx_badger_fraxbp.balanceOf(vault)
     assert staking_lp_balance == lp_balance
 
     # 3. lock in the vault
-    vault.convex.stake_lock(stkcvx_badger_fraxbp, staking_lp_balance, MIN_LOCK_TIME, PID)
+    vault.convex.stake_lock(
+        wcvx_badger_fraxbp,
+        staking_lp_balance,
+        MIN_LOCK_TIME,
+        vault.convex.VAULT_TYPES["BADGER_FRAXBP"],
+    )
 
     vault.post_safe_tx()


### PR DESCRIPTION
Tackles #930 

Vault creation:

```
brownie run issue/930/frax_stake_badgerfraxbp create_vault
```

Deposit in private vault:

```
brownie run issue/930/frax_stake_badgerfraxbp stake_in_vault
```

~**Note:** Leave it for now in draft since the vault creation is reverting with the following~

<img width="889" alt="Screenshot 2022-11-04 at 23 09 56" src="https://user-images.githubusercontent.com/84875062/200023296-5b533543-9fc9-4b1f-8028-7e5854a2d496.png">

Seems related with the pool being deactivated temp [tx](https://etherscan.io/tx/0x8409c611fcb02054a9bc30298b8885cd507909fefb0d8e68e84ec5a7e430d5eb#eventlog)

There appear to give another pid (*35*) for the same staking token, passed manually at the end, since there is duplicates with *33* as deactivated and hits first in the `get_pool_pid`

**Note:** for testing create a separate ganache instance and run in order: 1st `create_vault` then `stake_in_vault`
