### PR TITLE
chore: upload json files of queue tx for bricking upgradability

### DIFF
--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x01b9a3a35cda58b5166b0ee3eabca6a499e7fec6bd3eba6e9fae2c2736c0822d.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x01b9a3a35cda58b5166b0ee3eabca6a499e7fec6bd3eba6e9fae2c2736c0822d.json
@@ -1,0 +1,7 @@
+{
+    "data": "0000000000000000000000005dce29e92b1b939f8e8c60dcf15bde82a85be4a9000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130533,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x1dad77f1156ee39277baa2dc2e8251183099f59646357cc5d7641e454135d6cf.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x1dad77f1156ee39277baa2dc2e8251183099f59646357cc5d7641e454135d6cf.json
@@ -1,0 +1,7 @@
+{
+    "data": "000000000000000000000000f8f5677b6bcecdb9be94ae8f6770a05a6c53c378000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130541,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x26c4bd7016b7d7ea4718c7e0ae17ade809780b1340fbdfb5bcfb8629e5feb7d5.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x26c4bd7016b7d7ea4718c7e0ae17ade809780b1340fbdfb5bcfb8629e5feb7d5.json
@@ -1,0 +1,7 @@
+{
+    "data": "000000000000000000000000f349c0faa80fc1870306ac093f75934078e28991000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130532,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x28e7409cbce49338d7bbb4eadd9b565b1495675522a66fc673a69bf2e07768b4.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x28e7409cbce49338d7bbb4eadd9b565b1495675522a66fc673a69bf2e07768b4.json
@@ -1,0 +1,7 @@
+{
+    "data": "0000000000000000000000004b92d19c11435614cd49af1b589001b7c08cd4d5000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130541,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x30948efbbe42e3b5636d20ddfa03376ff91b9e3ff903af2d73bfd5cfdcea3dea.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x30948efbbe42e3b5636d20ddfa03376ff91b9e3ff903af2d73bfd5cfdcea3dea.json
@@ -1,0 +1,7 @@
+{
+    "data": "000000000000000000000000599d92b453c010b1050d31c364f6ee17e819f193000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130534,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x35ac96c50ec6cce42ca65b19686099cf411b96e0f9ebf759cb29d79a9a024cc2.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x35ac96c50ec6cce42ca65b19686099cf411b96e0f9ebf759cb29d79a9a024cc2.json
@@ -1,0 +1,7 @@
+{
+    "data": "0000000000000000000000008a8ffec8f4a0c8c9585da95d9d97e8cd6de273de000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130530,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x39ae02a8dfd8de9829458118a8b2e8a94afebac6cd386b0e581e4e34766dadc7.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x39ae02a8dfd8de9829458118a8b2e8a94afebac6cd386b0e581e4e34766dadc7.json
@@ -1,0 +1,7 @@
+{
+    "data": "00000000000000000000000055912d0cf83b75c492e761932abc4db4a5cb1b17000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130531,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x43b6af05d1721393cf6e596b2425a2bbe744938d2fd26f9434b6f1822882f18a.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x43b6af05d1721393cf6e596b2425a2bbe744938d2fd26f9434b6f1822882f18a.json
@@ -1,0 +1,7 @@
+{
+    "data": "000000000000000000000000b9d076fde463dbc9f915e5392f807315bf940334000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130527,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x655884dda0f3c60030c17cf8bf5a2540241a18c453f57e00facac638928e262c.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x655884dda0f3c60030c17cf8bf5a2540241a18c453f57e00facac638928e262c.json
@@ -1,0 +1,7 @@
+{
+    "data": "00000000000000000000000053c8e199eb2cb7c01543c137078a038937a68e40000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130534,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x72cb709d023aca0a20452da9017903451910cd1c470388c7efb2057220b3cdb6.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x72cb709d023aca0a20452da9017903451910cd1c470388c7efb2057220b3cdb6.json
@@ -1,0 +1,7 @@
+{
+    "data": "000000000000000000000000c17078fdd324cc473f8175dc5290fae5f2e84714000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130529,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x8e4c9e213ebac5b0b00ba8033017bf225b15a8d8f21fc4d4d2abdfa634bb5756.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x8e4c9e213ebac5b0b00ba8033017bf225b15a8d8f21fc4d4d2abdfa634bb5756.json
@@ -1,0 +1,7 @@
+{
+    "data": "00000000000000000000000027e98fc7d05f54e544d16f58c194c2d7ba71e3b5000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130540,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x98bcea4d78bdd51b168f5c022dda04908b6430d6138fcf8af8e7c99fe058230f.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x98bcea4d78bdd51b168f5c022dda04908b6430d6138fcf8af8e7c99fe058230f.json
@@ -1,0 +1,7 @@
+{
+    "data": "000000000000000000000000d04c48a53c111300ad41190d63681ed3dad998ec000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130526,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x9a4bbd9bcfa7fa7d544ed45b655013ccf65b71f961ae98808e0051cc76250f0e.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x9a4bbd9bcfa7fa7d544ed45b655013ccf65b71f961ae98808e0051cc76250f0e.json
@@ -1,0 +1,7 @@
+{
+    "data": "00000000000000000000000019d97d8fa813ee2f51ad4b4e04ea08baf4dffc28000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130529,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x9e00622033d5320af002654b244c9b8f6c2b0562d1bdc30d2c5c095b4c2cc6b0.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0x9e00622033d5320af002654b244c9b8f6c2b0562d1bdc30d2c5c095b4c2cc6b0.json
@@ -1,0 +1,7 @@
+{
+    "data": "00000000000000000000000026b8efa69603537ac8ab55768b6740b67664d518000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130535,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xaf9f8063e694122ca57449b3d9ea6248a7ef6e8cdaf8180322f1653027b5dbe3.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xaf9f8063e694122ca57449b3d9ea6248a7ef6e8cdaf8180322f1653027b5dbe3.json
@@ -1,0 +1,7 @@
+{
+    "data": "000000000000000000000000af5a1decfa95baf63e0084a35c62592b774a2a87000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130528,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xb04ba763cd63d04440202f3512272f34ee4c2934e16f498f8539500e19771da7.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xb04ba763cd63d04440202f3512272f34ee4c2934e16f498f8539500e19771da7.json
@@ -1,0 +1,7 @@
+{
+    "data": "000000000000000000000000235c9e24d3fb2fafd58a2e49d454fdcd2dbf7ff1000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130528,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xb250c486238a067546dd5d8914f040d49e348c35aaf7794ce51a147c020619ea.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xb250c486238a067546dd5d8914f040d49e348c35aaf7794ce51a147c020619ea.json
@@ -1,0 +1,7 @@
+{
+    "data": "00000000000000000000000019e4d89e0cb807ea21b8cef02df5eaa99a110da5000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130536,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xb9d97986db8ca1839c1ca408e6b9dd55e7588b7b79560e7a508cab5672865120.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xb9d97986db8ca1839c1ca408e6b9dd55e7588b7b79560e7a508cab5672865120.json
@@ -1,0 +1,7 @@
+{
+    "data": "0000000000000000000000007e7e112a68d8d2e221e11047a72ffc1065c38e1a000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130538,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xcc77767e4dbe0410cdf30fd457cef7b22dd23d5ea767add44179d735f680c648.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xcc77767e4dbe0410cdf30fd457cef7b22dd23d5ea767add44179d735f680c648.json
@@ -1,0 +1,7 @@
+{
+    "data": "00000000000000000000000088128580acdd9c04ce47afce196875747bf2a9f6000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130537,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xd7c17ea35b9a72803aa771f786c6ac9c0a8f9a4a7e8e1618a00007348c1df96f.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xd7c17ea35b9a72803aa771f786c6ac9c0a8f9a4a7e8e1618a00007348c1df96f.json
@@ -1,0 +1,7 @@
+{
+    "data": "000000000000000000000000758a43ee2bff8230eeb784879cdcff4828f2544d000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130538,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xe501fc29fff4f37419d6cfb32daa46912f940d003072bfadf80c4784185962cb.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xe501fc29fff4f37419d6cfb32daa46912f940d003072bfadf80c4784185962cb.json
@@ -1,0 +1,7 @@
+{
+    "data": "0000000000000000000000001862a18181346ebd9edaf800804f89190def24a5000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130539,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xefcb974e16bd72eaaec60e1cddaf7e6aa5a17cabcadad5f08f8df1caaf663922.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xefcb974e16bd72eaaec60e1cddaf7e6aa5a17cabcadad5f08f8df1caaf663922.json
@@ -1,0 +1,7 @@
+{
+    "data": "00000000000000000000000015cbc4ac1e81c97667780fe6dadedd04a6eeb47b000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130536,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xf94994e38c7a628f48d59e43a5facf92b57370890b50813f95d31b5334a90df5.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xf94994e38c7a628f48d59e43a5facf92b57370890b50813f95d31b5334a90df5.json
@@ -1,0 +1,7 @@
+{
+    "data": "000000000000000000000000be08ef12e4a553666291e9ffc24fccfd354f2dd2000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130533,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xf9dc1edd4026e807d6d6ca18940d88b774b6a265f36a4b7386940c83f52e3b05.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xf9dc1edd4026e807d6d6ca18940d88b774b6a265f36a4b7386940c83f52e3b05.json
@@ -1,0 +1,7 @@
+{
+    "data": "0000000000000000000000008c76970747afd5398e958bdfada4cf0b9fca16c4000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130531,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xfc56d279a71f93d30f49cfe61f5aeedf5edf1b465e9258209cb980c31986d818.json
+++ b/data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/0xfc56d279a71f93d30f49cfe61f5aeedf5edf1b465e9258209cb980c31986d818.json
@@ -1,0 +1,7 @@
+{
+    "data": "00000000000000000000000006d756861de0724fad5b5636124e0f252d3c1404000000000000000000000000933fdbac3773514384c6db30eb196a0be543d617",
+    "eta": 1669130542,
+    "eth": 0,
+    "signature": "changeProxyAdmin(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/scripts/issue/940/brick_deprecated.py
+++ b/scripts/issue/940/brick_deprecated.py
@@ -38,15 +38,17 @@ def main(queue="false", sim="true"):
                     ["address", "address"],
                     [vault.address, NEW_PROXY_ADMIN],
                 ),
-                dump_dir="data/badger/timelock/changeProxyAdmin/",
-                delay_in_days=4,
+                dump_dir="data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/",
+                delay_in_days=7,
             )
 
         safe.post_safe_tx()
 
     else:
         if sim != "true":
-            safe.badger.execute_timelock("data/badger/timelock/changeProxyAdmin/")
+            safe.badger.execute_timelock(
+                "data/badger/timelock/change_admin_brick_upgradability_deprecated_vaults/"
+            )
             safe.post_safe_tx()
         else:
             proxy_admin = Contract(


### PR DESCRIPTION
related to #948 

files required to later run the execution of queued txs, also includes the delay change to 7 days as it was requested by @dapp-whisperer at posting time and naming changes in the folder created to signal better the purpose for the records 