### PR TITLE
refactor great ape safe inits

### DIFF
--- a/great_ape_safe/ape_api/__init__.py
+++ b/great_ape_safe/ape_api/__init__.py
@@ -1,0 +1,18 @@
+import glob
+import os
+
+
+files = glob.glob("great_ape_safe/ape_api/[!_]*.py")
+module_names = [os.path.splitext(file)[0].replace("/", ".") for file in files]
+
+ape_apis = {}
+for module_path in module_names:
+    module = __import__(module_path, fromlist=[module_path.capitalize()])
+    class_name = module_path.split(".")[-1].capitalize()
+    init_name = module_path.split(".")[-1]
+    if "_" in class_name:
+        # e.g: Uni_v3 should be UniV3
+        i = class_name.index("_") + 1
+        class_name = class_name[:i] + class_name[i:].capitalize()
+        class_name = class_name.replace("_", "")
+    ape_apis[init_name] = getattr(module, class_name)

--- a/great_ape_safe/ape_api/__init__.py
+++ b/great_ape_safe/ape_api/__init__.py
@@ -2,20 +2,10 @@ import glob
 import os
 
 
-def module_path_to_class_name(module_path):
-    class_name = module_path.split(".")[-1].capitalize()
-    if "_" in class_name:
-        # e.g: Uni_v3 should be UniV3
-        i = class_name.index("_") + 1
-        class_name = class_name[:i] + class_name[i:].capitalize()
-        class_name = class_name.replace("_", "")
-    return class_name
-
-
 files = glob.glob("great_ape_safe/ape_api/[!_]*.py")
 ape_apis = {}
 for file in files:
     module_path = os.path.splitext(file)[0].replace("/", ".")
     module = __import__(module_path, fromlist=[module_path.capitalize()])
-    class_name = module_path_to_class_name(module_path)
+    class_name = module_path.split(".")[-1].title().replace("_", "")
     ape_apis[module_path.split(".")[-1]] = getattr(module, class_name)

--- a/great_ape_safe/ape_api/__init__.py
+++ b/great_ape_safe/ape_api/__init__.py
@@ -2,17 +2,20 @@ import glob
 import os
 
 
-files = glob.glob("great_ape_safe/ape_api/[!_]*.py")
-module_names = [os.path.splitext(file)[0].replace("/", ".") for file in files]
-
-ape_apis = {}
-for module_path in module_names:
-    module = __import__(module_path, fromlist=[module_path.capitalize()])
+def module_path_to_class_name(module_path):
     class_name = module_path.split(".")[-1].capitalize()
-    init_name = module_path.split(".")[-1]
     if "_" in class_name:
         # e.g: Uni_v3 should be UniV3
         i = class_name.index("_") + 1
         class_name = class_name[:i] + class_name[i:].capitalize()
         class_name = class_name.replace("_", "")
-    ape_apis[init_name] = getattr(module, class_name)
+    return class_name
+
+
+files = glob.glob("great_ape_safe/ape_api/[!_]*.py")
+ape_apis = {}
+for file in files:
+    module_path = os.path.splitext(file)[0].replace("/", ".")
+    module = __import__(module_path, fromlist=[module_path.capitalize()])
+    class_name = module_path_to_class_name(module_path)
+    ape_apis[module_path.split(".")[-1]] = getattr(module, class_name)

--- a/great_ape_safe/ape_api/spookyswap.py
+++ b/great_ape_safe/ape_api/spookyswap.py
@@ -2,7 +2,7 @@ from great_ape_safe.ape_api.uni_v2 import UniV2
 from helpers.addresses import registry
 
 
-class SpookySwap(UniV2):
+class Spookyswap(UniV2):
     def __init__(self, safe):
         self.safe = safe
         self.router = self.safe.contract(registry.ftm.spookyswap.router)

--- a/great_ape_safe/great_ape_safe.py
+++ b/great_ape_safe/great_ape_safe.py
@@ -40,7 +40,9 @@ class GreatApeSafe(ApeSafe):
             setattr(
                 self,
                 f"init_{class_name}",
-                lambda cn=class_name, c=cls: setattr(self, cn, c(self)),
+                lambda *args, cn=class_name, c=cls, **kwargs: setattr(
+                    self, cn, c(self, *args, **kwargs)
+                ),
             )
 
     def take_snapshot(self, tokens):

--- a/great_ape_safe/great_ape_safe.py
+++ b/great_ape_safe/great_ape_safe.py
@@ -14,28 +14,7 @@ from rich.pretty import pprint
 from tqdm import tqdm
 from web3.exceptions import BadFunctionCallOutput
 
-from great_ape_safe.ape_api.aave import Aave
-from great_ape_safe.ape_api.anyswap import Anyswap
-from great_ape_safe.ape_api.aura import Aura
-from great_ape_safe.ape_api.badger import Badger
-from great_ape_safe.ape_api.balancer import Balancer
-from great_ape_safe.ape_api.chainlink import Chainlink
-from great_ape_safe.ape_api.compound import Compound
-from great_ape_safe.ape_api.convex import Convex
-from great_ape_safe.ape_api.cow import Cow
-from great_ape_safe.ape_api.curve import Curve
-from great_ape_safe.ape_api.curve_v2 import CurveV2
-from great_ape_safe.ape_api.euler import Euler
-from great_ape_safe.ape_api.maker import Maker
-from great_ape_safe.ape_api.opolis import Opolis
-from great_ape_safe.ape_api.pancakeswap_v2 import PancakeswapV2
-from great_ape_safe.ape_api.rari import Rari
-from great_ape_safe.ape_api.snapshot import Snapshot
-from great_ape_safe.ape_api.solidly import Solidly
-from great_ape_safe.ape_api.spookyswap import SpookySwap
-from great_ape_safe.ape_api.sushi import Sushi
-from great_ape_safe.ape_api.uni_v2 import UniV2
-from great_ape_safe.ape_api.uni_v3 import UniV3
+from great_ape_safe.ape_api import ape_apis
 from helpers.chaindata import labels
 
 
@@ -57,80 +36,12 @@ class GreatApeSafe(ApeSafe):
     def __init__(self, address, base_url=None, multisend=None):
         super().__init__(address, base_url, multisend)
 
-    def init_all(self):
-        for method in self.__dir__():
-            if method.startswith("init_") and method != "init_all":
-                try:
-                    getattr(self, method)()
-                except exceptions.ContractNotFound:
-                    # different chain
-                    pass
-
-    def init_aave(self):
-        self.aave = Aave(self)
-
-    def init_anyswap(self):
-        self.anyswap = Anyswap(self)
-
-    def init_aura(self):
-        self.aura = Aura(self)
-
-    def init_badger(self):
-        self.badger = Badger(self)
-
-    def init_balancer(self):
-        self.balancer = Balancer(self)
-
-    def init_chainlink(self):
-        self.chainlink = Chainlink(self)
-
-    def init_compound(self):
-        self.compound = Compound(self)
-
-    def init_convex(self):
-        self.convex = Convex(self)
-
-    def init_cow(self, prod=False):
-        self.cow = Cow(self, prod)
-
-    def init_curve(self):
-        self.curve = Curve(self)
-
-    def init_curve_v2(self):
-        self.curve_v2 = CurveV2(self)
-
-    def init_euler(self):
-        self.euler = Euler(self)
-
-    def init_maker(self):
-        self.maker = Maker(self)
-
-    def init_opolis(self):
-        self.opolis = Opolis(self)
-
-    def init_pancakeswap_v2(self):
-        self.pancakeswap_v2 = PancakeswapV2(self)
-
-    def init_rari(self):
-        self.rari = Rari(self)
-
-    def init_snapshot(self, proposal_id):
-        self.snapshot = Snapshot(self, proposal_id)
-
-    def init_solidly(self):
-        self.solidly = Solidly(self)
-
-    def init_spookyswap(self):
-        self.spookyswap = SpookySwap(self)
-
-    def init_sushi(self):
-        self.sushi = Sushi(self)
-
-    def init_uni_v2(self):
-        self.uni_v2 = UniV2(self)
-
-    def init_uni_v3(self):
-        self.uni_v3 = UniV3(self)
+        for class_name, cls in ape_apis.items():
+            setattr(
+                self,
+                f"init_{class_name}",
+                lambda cn=class_name, c=cls: setattr(self, cn, c(self)),
+            )
 
     def take_snapshot(self, tokens):
         C.print(f"snapshotting {self.address}...")


### PR DESCRIPTION
have been wanting to do this for a long time, but wasn't able to materialize it until now

- dynamically create `GreatApeSafe.init_{api_name}` methods from an api dict (`{init name: Module}`)
- dynamically build api dict from modules in `great_ape_safe/ape_api/`

consequentially, adding an api to GreatApeSafe now just requires to add a module to `great_ape_safe/ape_api/`.
naming patterns are the same with the previous manual interface naming, thus being backwards compatible with all existing scripts.

for naming it is assumed you are following [pep-8](https://peps.python.org/pep-0008/#class-names) guidelines
`init name`: `init_{file name}`
`Module`: class name

e.g:
`great_ape_safe/ape_api/uni_v3.py `
```py
class UniV3:
```
can be accessed through:
```py
safe.init_uni_v3(); safe.uni_v3
```
