### PR TITLE
Verify if specific pid is indeed active/shutdown

### DIFF
--- a/great_ape_safe/ape_api/convex.py
+++ b/great_ape_safe/ape_api/convex.py
@@ -1,4 +1,3 @@
-from logging import shutdown
 from brownie import interface
 
 from helpers.addresses import registry

--- a/great_ape_safe/ape_api/convex.py
+++ b/great_ape_safe/ape_api/convex.py
@@ -1,3 +1,4 @@
+from logging import shutdown
 from brownie import interface
 
 from helpers.addresses import registry
@@ -39,8 +40,8 @@ class Convex:
         # https://docs.convexfinance.com/convexfinanceintegration/booster#pool-info
         n_pools = self.booster.poolLength()
         for n in range(n_pools):
-            lptoken, token, gauge, rewards, _, _ = self.booster.poolInfo(n)
-            if lptoken == underlying.address:
+            lptoken, token, gauge, rewards, _, shutdown = self.booster.poolInfo(n)
+            if lptoken == underlying.address and not shutdown:
                 return n, token, gauge, rewards
 
     def deposit(self, underlying, mantissa):
@@ -174,8 +175,8 @@ class Convex:
         len = self.frax_pool_registry.poolLength()
 
         for i in range(len):
-            _, _, staking_token, _, _ = self.frax_pool_registry.poolInfo(i)
-            if _staking_token == staking_token:
+            _, _, staking_token, _, active = self.frax_pool_registry.poolInfo(i)
+            if _staking_token == staking_token and active:
                 return i
 
     def get_vault(self, pid, owner=None):


### PR DESCRIPTION
Tackles #1023 

Since currently aura is undergoing the migration, whole system is under `shutdown` mode, likely all pid will show in that state. Advisable to verify the fix to fork other older block, e.g: [16150058](https://etherscan.io/block/16150058)