### PR TITLE
chore: update addresses for gas station watchlist

### DIFF
--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -70,13 +70,9 @@ ADDRESSES_ETH = {
         "ops_deployer2": "0xeE8b29AA52dD5fF2559da2C50b1887ADee257556",
         "ops_deployer3": "0x283C857BA940A61828d9F4c09e3fceE2e7aEF3f7",
         "ops_deployer4": "0xef42D748e09A2d9eF89238c053CE0B6f00236210",
-        "ops_deployer6": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
-        "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
         "ops_deployer8": "0x9082b0dD7A72c328833e6461965C9E91Cf59a960",
         "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
         # "ops_executor2": "0x8938bf50d1a3736bdA413510688834540858dAEA",  # can execute from deployer
-        "ops_executor3": "0xC69Fb085481bC8C4bfF99B924076656305D9a25D",
-        "ops_executor4": "0xE8eA1D8B3a5A4CEC7E94AE330fF18E82B5D22fA6",
         "ops_executor6": "0x66496eBB9d848C6A8F19612a6Dd10E09954532D0",
         # "ops_executor7": "0xaaE2051c2f74920C6662EF5C9B0d602C40D36DF4",  # can execute from deployer
         # "ops_executor8": "0x0a9af7FAba0d5DF7A8C881e1B9cd679ee07Af8A2",  # can execute from deployer
@@ -105,9 +101,13 @@ ADDRESSES_ETH = {
         "gas_station": "0x04C0205b9D900a49597d9a0345aEAD6D73307C3B",
         "_deprecated": {
             "ops_executor1": "0xcf4fF1e03830D692F52EB094c52A5A6A2181Ab3F",
+            "ops_executor3": "0xC69Fb085481bC8C4bfF99B924076656305D9a25D",
             "ops_deployer5": "0xC6a902de22b10cb176460777ce6e7A12A6b6AE5a",
             "ops_deployer6": "0x7c1D678685B9d2F65F1909b9f2E544786807d46C",
+            "ops_deployer6_v2": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
+            "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
             "ops_executor4": "0xBB2281cA5B4d07263112604D1F182AD0Ab26a252",
+            "ops_executor4_v2": "0xE8eA1D8B3a5A4CEC7E94AE330fF18E82B5D22fA6",
             "ops_executor5": "0xcDAb3AcC1AD3870a93BB72377092B67e290D76f3",
             "ops_guardian": "0x29F7F8896Fb913CF7f9949C623F896a154727919",
             "ops_keeper": "0x872213E29C85d7e30F1C8202FC47eD1Ec124BB1D",
@@ -721,10 +721,12 @@ ADDRESSES_POLYGON = {
         "ops_deployer3": "0x283C857BA940A61828d9F4c09e3fceE2e7aEF3f7",
         "ops_deployer4": "0xef42D748e09A2d9eF89238c053CE0B6f00236210",
         "ops_deployer5": "0xC6a902de22b10cb176460777ce6e7A12A6b6AE5a",
-        "ops_deployer6": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
-        "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
         "ops_deployer8": "0x9082b0dD7A72c328833e6461965C9E91Cf59a960",
         "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
+        "_deprecated": {
+            "ops_deployer6": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
+            "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
+        },
     },
     "treasury_tokens": {
         "BADGER": "0x1FcbE5937B0cc2adf69772D228fA4205aCF4D9b2",
@@ -774,13 +776,9 @@ ADDRESSES_ARBITRUM = {
         "ops_deployer3": "0x283C857BA940A61828d9F4c09e3fceE2e7aEF3f7",
         "ops_deployer4": "0xef42D748e09A2d9eF89238c053CE0B6f00236210",
         "ops_deployer5": "0xC6a902de22b10cb176460777ce6e7A12A6b6AE5a",
-        "ops_deployer6": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
-        "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
         "ops_deployer8": "0x9082b0dD7A72c328833e6461965C9E91Cf59a960",
         "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
         "ops_executor2": "0x8938bf50d1a3736bdA413510688834540858dAEA",
-        "ops_executor3": "0xC69Fb085481bC8C4bfF99B924076656305D9a25D",
-        "ops_executor4": "0xE8eA1D8B3a5A4CEC7E94AE330fF18E82B5D22fA6",
         "ops_executor8": "0x0a9af7FAba0d5DF7A8C881e1B9cd679ee07Af8A2",
         "ops_executor9": "0x69874C84a30A3742cC2b624238CfEEa24CF5eF82",
         "ops_executor10": "0xaF94D299a73c4545ff702E79D16d9fb1AB5BDAbF",
@@ -789,7 +787,11 @@ ADDRESSES_ARBITRUM = {
         "ops_botsquad": "0xF8dbb94608E72A3C4cEeAB4ad495ac51210a341e",
         "ops_botsquad_cycle0": "0x1a6D6D120a7e3F71B084b4023a518c72F1a93EE9",
         "_deprecated": {
+            "ops_deployer6": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
+            "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
             "ops_executor1": "0xcf4fF1e03830D692F52EB094c52A5A6A2181Ab3F",
+            "ops_executor3": "0xC69Fb085481bC8C4bfF99B924076656305D9a25D",
+            "ops_executor4": "0xE8eA1D8B3a5A4CEC7E94AE330fF18E82B5D22fA6",
         },
     },
     "sett_vaults": {
@@ -911,12 +913,12 @@ ADDRESSES_RINKEBY = {
         "solo_multisig": "0x4e9B82f40a657105b083db308D33E93789329ddb",
         "gas_station": "0x747a4c9073B68AE16A29e65f4b95C9bbEa1E19cD",
         "ops_deployer3": "0x283C857BA940A61828d9F4c09e3fceE2e7aEF3f7",
-        "ops_executor3": "0xC69Fb085481bC8C4bfF99B924076656305D9a25D",
         "ops_executor7": "0xaaE2051c2f74920C6662EF5C9B0d602C40D36DF4",
         "ops_executor8": "0x0a9af7FAba0d5DF7A8C881e1B9cd679ee07Af8A2",
         "ops_executor12": "0xD3cee5e327715Ad1195DcE8FD571c564cD2100E7",
         "_deprecated": {
             "ops_executor1": "0xcf4fF1e03830D692F52EB094c52A5A6A2181Ab3F",
+            "ops_executor3": "0xC69Fb085481bC8C4bfF99B924076656305D9a25D",
         },
     },
     "treasury_tokens": {
@@ -950,13 +952,9 @@ ADDRESSES_FANTOM = {
         "ops_deployer3": "0x283C857BA940A61828d9F4c09e3fceE2e7aEF3f7",
         "ops_deployer4": "0xef42D748e09A2d9eF89238c053CE0B6f00236210",
         "ops_deployer5": "0xC6a902de22b10cb176460777ce6e7A12A6b6AE5a",
-        "ops_deployer6": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
-        "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
         "ops_deployer8": "0x9082b0dD7A72c328833e6461965C9E91Cf59a960",
         "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
         "ops_executor2": "0x8938bf50d1a3736bdA413510688834540858dAEA",
-        "ops_executor3": "0xC69Fb085481bC8C4bfF99B924076656305D9a25D",
-        "ops_executor4": "0xE8eA1D8B3a5A4CEC7E94AE330fF18E82B5D22fA6",
         "ops_executor6": "0x66496eBB9d848C6A8F19612a6Dd10E09954532D0",
         "ops_executor7": "0xaaE2051c2f74920C6662EF5C9B0d602C40D36DF4",
         "ops_executor8": "0x0a9af7FAba0d5DF7A8C881e1B9cd679ee07Af8A2",
@@ -966,7 +964,11 @@ ADDRESSES_FANTOM = {
         "devProxyAdmin": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF",
         "guardian": "0x576DFDEc454792773dD26a781177CF998aA832E3",
         "_deprecated": {
+            "ops_deployer6": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
+            "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
             "ops_executor1": "0xcf4fF1e03830D692F52EB094c52A5A6A2181Ab3F",
+            "ops_executor3": "0xC69Fb085481bC8C4bfF99B924076656305D9a25D",
+            "ops_executor4": "0xE8eA1D8B3a5A4CEC7E94AE330fF18E82B5D22fA6",
         },
     },
     "treasury_tokens": {
@@ -1016,10 +1018,12 @@ ADDRESSES_OPTIMISM = {
         "ops_deployer3": "0x283C857BA940A61828d9F4c09e3fceE2e7aEF3f7",
         "ops_deployer4": "0xef42D748e09A2d9eF89238c053CE0B6f00236210",
         "ops_deployer5": "0xC6a902de22b10cb176460777ce6e7A12A6b6AE5a",
-        "ops_deployer6": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
-        "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
         "ops_deployer8": "0x9082b0dD7A72c328833e6461965C9E91Cf59a960",
         "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
+        "_deprecated": {
+            "ops_deployer6": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
+            "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
+        },
     },
 }
 

--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -71,7 +71,6 @@ ADDRESSES_ETH = {
         "ops_deployer3": "0x283C857BA940A61828d9F4c09e3fceE2e7aEF3f7",
         "ops_deployer4": "0xef42D748e09A2d9eF89238c053CE0B6f00236210",
         "ops_deployer8": "0x9082b0dD7A72c328833e6461965C9E91Cf59a960",
-        "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
         # "ops_executor2": "0x8938bf50d1a3736bdA413510688834540858dAEA",  # can execute from deployer
         "ops_executor6": "0x66496eBB9d848C6A8F19612a6Dd10E09954532D0",
         # "ops_executor7": "0xaaE2051c2f74920C6662EF5C9B0d602C40D36DF4",  # can execute from deployer
@@ -106,6 +105,7 @@ ADDRESSES_ETH = {
             "ops_deployer6": "0x7c1D678685B9d2F65F1909b9f2E544786807d46C",
             "ops_deployer6_v2": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
             "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
+            "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
             "ops_executor4": "0xBB2281cA5B4d07263112604D1F182AD0Ab26a252",
             "ops_executor4_v2": "0xE8eA1D8B3a5A4CEC7E94AE330fF18E82B5D22fA6",
             "ops_executor5": "0xcDAb3AcC1AD3870a93BB72377092B67e290D76f3",
@@ -722,10 +722,10 @@ ADDRESSES_POLYGON = {
         "ops_deployer4": "0xef42D748e09A2d9eF89238c053CE0B6f00236210",
         "ops_deployer5": "0xC6a902de22b10cb176460777ce6e7A12A6b6AE5a",
         "ops_deployer8": "0x9082b0dD7A72c328833e6461965C9E91Cf59a960",
-        "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
         "_deprecated": {
             "ops_deployer6": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
             "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
+            "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
         },
     },
     "treasury_tokens": {
@@ -777,7 +777,6 @@ ADDRESSES_ARBITRUM = {
         "ops_deployer4": "0xef42D748e09A2d9eF89238c053CE0B6f00236210",
         "ops_deployer5": "0xC6a902de22b10cb176460777ce6e7A12A6b6AE5a",
         "ops_deployer8": "0x9082b0dD7A72c328833e6461965C9E91Cf59a960",
-        "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
         "ops_executor2": "0x8938bf50d1a3736bdA413510688834540858dAEA",
         "ops_executor8": "0x0a9af7FAba0d5DF7A8C881e1B9cd679ee07Af8A2",
         "ops_executor9": "0x69874C84a30A3742cC2b624238CfEEa24CF5eF82",
@@ -789,6 +788,7 @@ ADDRESSES_ARBITRUM = {
         "_deprecated": {
             "ops_deployer6": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
             "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
+            "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
             "ops_executor1": "0xcf4fF1e03830D692F52EB094c52A5A6A2181Ab3F",
             "ops_executor3": "0xC69Fb085481bC8C4bfF99B924076656305D9a25D",
             "ops_executor4": "0xE8eA1D8B3a5A4CEC7E94AE330fF18E82B5D22fA6",
@@ -953,7 +953,6 @@ ADDRESSES_FANTOM = {
         "ops_deployer4": "0xef42D748e09A2d9eF89238c053CE0B6f00236210",
         "ops_deployer5": "0xC6a902de22b10cb176460777ce6e7A12A6b6AE5a",
         "ops_deployer8": "0x9082b0dD7A72c328833e6461965C9E91Cf59a960",
-        "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
         "ops_executor2": "0x8938bf50d1a3736bdA413510688834540858dAEA",
         "ops_executor6": "0x66496eBB9d848C6A8F19612a6Dd10E09954532D0",
         "ops_executor7": "0xaaE2051c2f74920C6662EF5C9B0d602C40D36DF4",
@@ -966,6 +965,7 @@ ADDRESSES_FANTOM = {
         "_deprecated": {
             "ops_deployer6": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
             "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
+            "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
             "ops_executor1": "0xcf4fF1e03830D692F52EB094c52A5A6A2181Ab3F",
             "ops_executor3": "0xC69Fb085481bC8C4bfF99B924076656305D9a25D",
             "ops_executor4": "0xE8eA1D8B3a5A4CEC7E94AE330fF18E82B5D22fA6",
@@ -1019,10 +1019,10 @@ ADDRESSES_OPTIMISM = {
         "ops_deployer4": "0xef42D748e09A2d9eF89238c053CE0B6f00236210",
         "ops_deployer5": "0xC6a902de22b10cb176460777ce6e7A12A6b6AE5a",
         "ops_deployer8": "0x9082b0dD7A72c328833e6461965C9E91Cf59a960",
-        "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
         "_deprecated": {
             "ops_deployer6": "0x96AC69183216074dd8CFA7A380e873380445EaDc",
             "ops_deployer7": "0x7140B5254d80154f9Fc5F86054efB210f3a1e2c6",
+            "ops_deployer9": "0xd49177c4cF4b8cCdf58475c9a155C4CD8b9F3F31",
         },
     },
 }


### PR DESCRIPTION
deprecates some deployers and executors in order to be able to update the gas station watchlist

partial solve for:
- #1055 
- #1068 
- #1070 