### PR TITLE
feat: add flag for simplified audit of signer roles

### DIFF
--- a/scripts/badger/audit_owners.py
+++ b/scripts/badger/audit_owners.py
@@ -30,7 +30,11 @@ def label_in_address_book(addr):
         return False
 
 
-def main():
+def find_roles_only():
+    main(extensive=False)
+
+
+def main(extensive=True):
     # loop over multisigs
     data = []
     for chain in ["eth", "bsc", "poly", "arbitrum", "ftm"]:
@@ -59,11 +63,15 @@ def main():
     df = df.set_index(["address", "chain"])
     df = df.explode("owners")
 
-    # map owner to label
-    df["public_label"] = df["owners"].map(label_in_address_book)
+    if extensive == True:
+        # map owner to label
+        df["public_label"] = df["owners"].map(label_in_address_book)
 
     # map owner to role
     df["owner_role"] = df["owners"].map(roles)
+
+    if extensive == False:
+        df = df.dropna()
 
     # print and dump result
     print(df)


### PR DESCRIPTION
@sajanrajdev my suggestion would something like this; add a flag for a simplified audit run.

with `audit_owners_mapper.py`:
```
roles = {
    "0x96AC69183216074dd8CFA7A380e873380445EaDc": "find_me",
}
```
`$  brownie run badger/audit_owners find_roles_only` yields:
```
address,chain,label,threshold,owners,owner_role
0xeb7341c89ba46CC7945f75Bd5dD7a04f8FA16327,poly,techops_multisig,3,0x96AC69183216074dd8CFA7A380e873380445EaDc,find_me
0x292549E6bd5a41aE4521Bb8679aDA59631B9eD4C,arbitrum,techops_multisig,3,0x96AC69183216074dd8CFA7A380e873380445EaDc,find_me
0xb364bAb258ad35dd83c7dd4E8AC78676b7aa1e9F,arbitrum,dev_multisig,3,0x96AC69183216074dd8CFA7A380e873380445EaDc,find_me
0x781E82D5D49042baB750efac91858cB65C6b0582,ftm,techops_multisig,3,0x96AC69183216074dd8CFA7A380e873380445EaDc,find_me
```