### PR TITLE
Integrate upkeep manager in gas st and add existing upkeep ids members

### DIFF
--- a/great_ape_safe/ape_api/badger.py
+++ b/great_ape_safe/ape_api/badger.py
@@ -423,7 +423,7 @@ class Badger:
                 continue
             if "executor" in label:
                 min_bal = 1e18
-            if "upkeep" in label:
+            if "upkeep_manager" in label:
                 min_bal = 1e18
             if label == "ops_botsquad":
                 min_bal = 5e18

--- a/great_ape_safe/ape_api/badger.py
+++ b/great_ape_safe/ape_api/badger.py
@@ -423,7 +423,7 @@ class Badger:
                 continue
             if "executor" in label:
                 min_bal = 1e18
-            if "upkeep_manager" in label:
+            if label == "upkeep_manager":
                 min_bal = 1e18
             if label == "ops_botsquad":
                 min_bal = 5e18

--- a/great_ape_safe/ape_api/badger.py
+++ b/great_ape_safe/ape_api/badger.py
@@ -419,9 +419,11 @@ class Badger:
         for label, addr in r.badger_wallets.items():
             min_bal = 2e18
             min_top_up = 0.5e18
-            if not label.startswith("ops_") or "multisig" in label:
+            if not label.startswith(tuple(["ops_", "upkeep_"])) or "multisig" in label:
                 continue
             if "executor" in label:
+                min_bal = 1e18
+            if "upkeep" in label:
                 min_bal = 1e18
             if label == "ops_botsquad":
                 min_bal = 5e18

--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -101,6 +101,7 @@ ADDRESSES_ETH = {
         "badgerHunt": "0x394DCfbCf25C5400fcC147EbD9970eD34A474543",
         "rewardsEscrow": "0xBE838aE7f6Ba97e7Eb545a3f43eE96FfBb3184DC",
         "gas_station": "0x04C0205b9D900a49597d9a0345aEAD6D73307C3B",
+        "upkeep_manager": "0x4c02f0160Dc0387b13bCb5e1728C780649E109Ac",
         "_deprecated": {
             "ops_executor1": "0xcf4fF1e03830D692F52EB094c52A5A6A2181Ab3F",
             "ops_executor3": "0xC69Fb085481bC8C4bfF99B924076656305D9a25D",

--- a/scripts/issue/1133/upkeep_manager_integration.py
+++ b/scripts/issue/1133/upkeep_manager_integration.py
@@ -79,16 +79,6 @@ def register_members_in_manager():
 
     for name, upkeep_id in members.items():
         if name == "GasStationExact":
-            (
-                member_address,
-                gas_limit,
-                _,
-                _,
-                _,
-                _,
-                _,
-                _,
-            ) = techops.chainlink.keeper_registry_v1_1.getUpkeep(upkeep_id)
             # NOTE: moving forward makes more sense to have links funds in upkeep manager
             techops.chainlink.keeper_registry_v1_1.withdrawFunds(
                 upkeep_id, upkeep_manager

--- a/scripts/issue/1133/upkeep_manager_integration.py
+++ b/scripts/issue/1133/upkeep_manager_integration.py
@@ -84,16 +84,9 @@ def register_members_in_manager():
                 upkeep_id, upkeep_manager
             )
         else:
-            (
-                member_address,
-                gas_limit,
-                _,
-                _,
-                _,
-                _,
-                _,
-                _,
-            ) = techops.chainlink.keeper_registry.getUpkeep(upkeep_id)
+            member_address, gas_limit = techops.chainlink.keeper_registry.getUpkeep(
+                upkeep_id
+            )[0:2]
             techops.chainlink.keeper_registry.withdrawFunds(upkeep_id, upkeep_manager)
             # https://etherscan.io/address/0x4c02f0160dc0387b13bcb5e1728c780649e109ac#code#F16#L166
             upkeep_manager.addMember(member_address, name, gas_limit, 0)

--- a/scripts/issue/1133/upkeep_manager_integration.py
+++ b/scripts/issue/1133/upkeep_manager_integration.py
@@ -1,0 +1,39 @@
+from brownie import interface
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import r
+
+"""
+UpKeep references:
+gas station: https://automation.chain.link/mainnet/89
+treasury voter: https://automation.chain.link/mainnet/42960818007215227498102337773007812241122867237937589685113781988946396009556
+tree dripper: https://automation.chain.link/mainnet/16015974269903908984725510916384725148630916297368865448620388766630414318319
+rembadger dripper: https://automation.chain.link/mainnet/98030557125143332209375009711552185081207413079136145061022651896587613727137
+"""
+members = {
+    "RemBadgerDripper2023": 98030557125143332209375009711552185081207413079136145061022651896587613727137,
+    "TreeDripper2023": 16015974269903908984725510916384725148630916297368865448620388766630414318319,
+    "TreasuryVoterModule": 42960818007215227498102337773007812241122867237937589685113781988946396009556,
+    # TODO: "GasStationExact": 0 Belongs to old registry, should we cancel it in old registry and register it in the new?
+}
+
+
+def main():
+    techops = GreatApeSafe(r.badger_wallets.techops_multisig)
+    techops.init_badger()
+
+    # contracts involved
+    cl_registry = techops.contract(
+        r.chainlink.keeper_registry, interface.IKeeperRegistry
+    )
+    upkeep_manager = techops.contract(r.badger_wallets.upkeep_manager)
+
+    # 1. Add existing members
+    for name, upkeep_id in members.items():
+        member_address, gas_limit, _, _, _, _, _, _ = cl_registry.getUpkeep(upkeep_id)
+        # https://etherscan.io/address/0x4c02f0160dc0387b13bcb5e1728c780649e109ac#code#F16#L166
+        upkeep_manager.addMember(member_address, name, gas_limit, upkeep_id)
+
+    # 2. Include manager in gas st watchlist
+    techops.badger.set_gas_station_watchlist()
+
+    techops.post_safe_tx(call_trace=True)

--- a/scripts/issue/1133/upkeep_manager_integration.py
+++ b/scripts/issue/1133/upkeep_manager_integration.py
@@ -58,8 +58,8 @@ def initial_setup_and_testing(sim=False):
 
     upkeep_manager.addMember(r.drippers.tree_2022_q2, "TreeDripper2022Q2", 400_000, 0)
 
+    upkeep_manager_snap.print_snapshot()
     if not sim:
-        upkeep_manager_snap.print_snapshot()
         techops.post_safe_tx(call_trace=True)
 
 
@@ -100,14 +100,14 @@ def register_members_in_manager(sim=False):
             techops.chainlink.keeper_registry_v1_1.withdrawFunds(
                 upkeep_id, upkeep_manager
             )
-            upkeep_manager.addMember(member_address, name, gas_limit, 0)
         else:
             member_address, gas_limit = techops.chainlink.keeper_registry.getUpkeep(
                 upkeep_id
             )[0:2]
             techops.chainlink.keeper_registry.withdrawFunds(upkeep_id, upkeep_manager)
-            # https://etherscan.io/address/0x4c02f0160dc0387b13bcb5e1728c780649e109ac#code#F16#L166
-            upkeep_manager.addMember(member_address, name, gas_limit, 0)
+
+        # https://etherscan.io/address/0x4c02f0160dc0387b13bcb5e1728c780649e109ac#code#F16#L166
+        upkeep_manager.addMember(member_address, name, gas_limit, 0)
 
     upkeep_manager.setRoundsTopUp(INITIAL_ROUNDS_TOP_UP)
 

--- a/scripts/issue/1133/upkeep_manager_integration.py
+++ b/scripts/issue/1133/upkeep_manager_integration.py
@@ -16,24 +16,115 @@ members = {
     "GasStationExact": 89,
 }
 
+techops = GreatApeSafe(r.badger_wallets.techops_multisig)
+upkeep_manager_snap = GreatApeSafe(r.badger_wallets.upkeep_manager)
 
-def main():
-    techops = GreatApeSafe(r.badger_wallets.techops_multisig)
+# contract
+upkeep_manager = techops.contract(r.badger_wallets.upkeep_manager)
+
+
+def initial_setup():
+    """
+    carries the following actions: cancels upkeeps from both registries,
+    sends techops link funds to manager, init the base upkeep in the manager,
+    updates watchlist, updates registry used in the gas station to latest and
+    register the gas station so it sends 1 eth to the manager
+    """
     techops.init_badger()
+    techops.init_chainlink()
 
-    # contracts involved
-    cl_registry = techops.contract(
-        r.chainlink.keeper_registry, interface.IKeeperRegistry
-    )
-    upkeep_manager = techops.contract(r.badger_wallets.upkeep_manager)
+    # snaps
+    techops.take_snapshot([techops.chainlink.link])
+    upkeep_manager_snap.take_snapshot([techops.chainlink.link])
 
-    # 1. Add existing members
+    initial_rounds_top_up = upkeep_manager.roundsTopUp()
+
+    # 1. Send links funds to allow to init base upkeep job
+    link_bal = techops.chainlink.link.balanceOf(techops)
+    techops.chainlink.link.transfer(upkeep_manager, link_bal)
+
+    # NOTE: reduce the min rounds so we can initialize it, since techops only has 90 LINK
+    upkeep_manager.setRoundsTopUp(2)
+
+    # NOTE: while testing with foundry, setting up on this figure have not seen any revert
+    # on top-up actions or withdrawal of funds from the keepers.
+    # ref: https://github.com/Badger-Finance/badger-avatars/blob/main/test/upkeeps/UpKeepManagerTest.t.sol
+    upkeep_manager.initializeBaseUpkeep(1_000_000)
+
+    upkeep_manager_snap.print_snapshot()
+
+    # 2. Cancel upkeep in old and new registry to migrate ownership to the upkeep manager
     for name, upkeep_id in members.items():
-        member_address, gas_limit, _, _, _, _, _, _ = cl_registry.getUpkeep(upkeep_id)
-        # https://etherscan.io/address/0x4c02f0160dc0387b13bcb5e1728c780649e109ac#code#F16#L166
-        upkeep_manager.addMember(member_address, name, gas_limit, upkeep_id)
+        if name == "GasStationExact":
+            techops.chainlink.keeper_registry_v1_1.cancelUpkeep(upkeep_id)
+        else:
+            techops.chainlink.keeper_registry.cancelUpkeep(upkeep_id)
 
-    # 2. Include manager in gas st watchlist
+    # 3. Update gas station
     techops.badger.set_gas_station_watchlist()
 
+    # 4. Set `s_keeperRegistryAddress` to latest cl registry
+    techops.badger.station.setKeeperRegistryAddress(techops.chainlink.keeper_registry)
+
+    # 5. Add gas st in this tx with the left-over link funds to auto-fund the manager in next block with eth
+    upkeep_manager.addMember(techops.badger.station, "GasStationExact", 400_000, 0)
+    upkeep_manager.setRoundsTopUp(initial_rounds_top_up)
+
+    upkeep_manager_snap.print_snapshot()
     techops.post_safe_tx(call_trace=True)
+
+
+def register_members_in_manager():
+    techops.init_chainlink()
+
+    for name, upkeep_id in members.items():
+        if name == "GasStationExact":
+            (
+                member_address,
+                gas_limit,
+                _,
+                _,
+                _,
+                _,
+                _,
+                _,
+            ) = techops.chainlink.keeper_registry_v1_1.getUpkeep(upkeep_id)
+            # NOTE: moving forward makes more sense to have links funds in upkeep manager
+            techops.chainlink.keeper_registry_v1_1.withdrawFunds(
+                upkeep_id, upkeep_manager
+            )
+        else:
+            (
+                member_address,
+                gas_limit,
+                _,
+                _,
+                _,
+                _,
+                _,
+                _,
+            ) = techops.chainlink.keeper_registry.getUpkeep(upkeep_id)
+            techops.chainlink.keeper_registry.withdrawFunds(upkeep_id, upkeep_manager)
+            # https://etherscan.io/address/0x4c02f0160dc0387b13bcb5e1728c780649e109ac#code#F16#L166
+            upkeep_manager.addMember(member_address, name, gas_limit, 0)
+
+    techops.post_safe_tx()
+
+
+def register_dummy_member():
+    """
+    registers an old dripper to test the flow of registration in the cl registry
+    and later being able to cancel
+    """
+    upkeep_manager.addMember(r.drippers.tree_2022_q2, "TreeDripper2022Q2", 400_000, 0)
+
+    techops.post_safe_tx()
+
+
+def cancel_dummy_member():
+    """
+    cancels the old dripper
+    """
+    upkeep_manager.cancelMemberUpkeep(r.drippers.tree_2022_q2)
+
+    techops.post_safe_tx()

--- a/scripts/issue/1133/upkeep_manager_integration.py
+++ b/scripts/issue/1133/upkeep_manager_integration.py
@@ -48,7 +48,7 @@ def initial_setup():
 
     # NOTE: while testing with foundry, setting up on this figure have not seen any revert
     # on top-up actions or withdrawal of funds from the keepers.
-    # ref: https://github.com/Badger-Finance/badger-avatars/blob/main/test/upkeeps/UpKeepManagerTest.t.sol
+    # ref of gas snap: https://github.com/Badger-Finance/badger-avatars/blob/main/.gas-snapshot#L166-L176
     upkeep_manager.initializeBaseUpkeep(1_000_000)
 
     upkeep_manager_snap.print_snapshot()

--- a/scripts/issue/1133/upkeep_manager_integration.py
+++ b/scripts/issue/1133/upkeep_manager_integration.py
@@ -1,4 +1,4 @@
-from brownie import interface
+from brownie import chain
 from great_ape_safe import GreatApeSafe
 from helpers.addresses import r
 
@@ -21,23 +21,28 @@ upkeep_manager_snap = GreatApeSafe(r.badger_wallets.upkeep_manager)
 
 # contract
 upkeep_manager = techops.contract(r.badger_wallets.upkeep_manager)
+INITIAL_ROUNDS_TOP_UP = 20
+
+techops.init_badger()
+techops.init_chainlink()
 
 
-def initial_setup():
+def sim():
+    initial_setup_and_testing(sim=True)
+    cancel_dummy_member(sim=True)
+    cancel_upkeeps(sim=True)
+    chain.mine(51)
+    register_members_in_manager(sim=True)
+
+
+def initial_setup_and_testing(sim=False):
     """
-    carries the following actions: cancels upkeeps from both registries,
-    sends techops link funds to manager, init the base upkeep in the manager,
-    updates watchlist, updates registry used in the gas station to latest and
-    register the gas station so it sends 1 eth to the manager
+    carries the following actions: sends techops link funds to manager,
+    init the base upkeep in the manager and adds a dummy member for testing
     """
-    techops.init_badger()
-    techops.init_chainlink()
-
     # snaps
     techops.take_snapshot([techops.chainlink.link])
     upkeep_manager_snap.take_snapshot([techops.chainlink.link])
-
-    initial_rounds_top_up = upkeep_manager.roundsTopUp()
 
     # 1. Send links funds to allow to init base upkeep job
     link_bal = techops.chainlink.link.balanceOf(techops)
@@ -51,38 +56,51 @@ def initial_setup():
     # ref of gas snap: https://github.com/Badger-Finance/badger-avatars/blob/main/.gas-snapshot#L166-L176
     upkeep_manager.initializeBaseUpkeep(1_000_000)
 
-    upkeep_manager_snap.print_snapshot()
+    upkeep_manager.addMember(r.drippers.tree_2022_q2, "TreeDripper2022Q2", 400_000, 0)
 
-    # 2. Cancel upkeep in old and new registry to migrate ownership to the upkeep manager
+    if not sim:
+        upkeep_manager_snap.print_snapshot()
+        techops.post_safe_tx(call_trace=True)
+
+
+def cancel_upkeeps(sim=False):
+    """
+    carries the following actions: cancels upkeeps from both registries,
+    updates watchlist and updates registry used in the gas station to latest
+    """
+    # 1. Cancel upkeep in old and new registry to migrate ownership to the upkeep manager
     for name, upkeep_id in members.items():
         if name == "GasStationExact":
             techops.chainlink.keeper_registry_v1_1.cancelUpkeep(upkeep_id)
         else:
             techops.chainlink.keeper_registry.cancelUpkeep(upkeep_id)
 
-    # 3. Update gas station
+    # 2. Update gas station
     techops.badger.set_gas_station_watchlist()
 
-    # 4. Set `s_keeperRegistryAddress` to latest cl registry
+    # 3. Set `s_keeperRegistryAddress` to latest cl registry
     techops.badger.station.setKeeperRegistryAddress(techops.chainlink.keeper_registry)
 
-    # 5. Add gas st in this tx with the left-over link funds to auto-fund the manager in next block with eth
-    upkeep_manager.addMember(techops.badger.station, "GasStationExact", 400_000, 0)
-    upkeep_manager.setRoundsTopUp(initial_rounds_top_up)
-
-    upkeep_manager_snap.print_snapshot()
-    techops.post_safe_tx(call_trace=True)
+    if not sim:
+        techops.post_safe_tx(call_trace=True)
 
 
-def register_members_in_manager():
-    techops.init_chainlink()
-
+def register_members_in_manager(sim=False):
+    """
+    registers all members in the upkeep manager reading the
+    target address and gas limit from old and latest cl registry
+    """
     for name, upkeep_id in members.items():
         if name == "GasStationExact":
+            (
+                member_address,
+                gas_limit,
+            ) = techops.chainlink.keeper_registry_v1_1.getUpkeep(upkeep_id)[0:2]
             # NOTE: moving forward makes more sense to have links funds in upkeep manager
             techops.chainlink.keeper_registry_v1_1.withdrawFunds(
                 upkeep_id, upkeep_manager
             )
+            upkeep_manager.addMember(member_address, name, gas_limit, 0)
         else:
             member_address, gas_limit = techops.chainlink.keeper_registry.getUpkeep(
                 upkeep_id
@@ -91,23 +109,19 @@ def register_members_in_manager():
             # https://etherscan.io/address/0x4c02f0160dc0387b13bcb5e1728c780649e109ac#code#F16#L166
             upkeep_manager.addMember(member_address, name, gas_limit, 0)
 
-    techops.post_safe_tx()
+    upkeep_manager.setRoundsTopUp(INITIAL_ROUNDS_TOP_UP)
+
+    if not sim:
+        techops.post_safe_tx(call_trace=True)
+    else:
+        techops.post_safe_tx(skip_preview=True)
 
 
-def register_dummy_member():
-    """
-    registers an old dripper to test the flow of registration in the cl registry
-    and later being able to cancel
-    """
-    upkeep_manager.addMember(r.drippers.tree_2022_q2, "TreeDripper2022Q2", 400_000, 0)
-
-    techops.post_safe_tx()
-
-
-def cancel_dummy_member():
+def cancel_dummy_member(sim=False):
     """
     cancels the old dripper
     """
     upkeep_manager.cancelMemberUpkeep(r.drippers.tree_2022_q2)
 
-    techops.post_safe_tx()
+    if not sim:
+        techops.post_safe_tx()

--- a/scripts/issue/1133/upkeep_manager_integration.py
+++ b/scripts/issue/1133/upkeep_manager_integration.py
@@ -3,7 +3,7 @@ from great_ape_safe import GreatApeSafe
 from helpers.addresses import r
 
 """
-UpKeep references:
+Upkeep references:
 gas station: https://automation.chain.link/mainnet/89
 treasury voter: https://automation.chain.link/mainnet/42960818007215227498102337773007812241122867237937589685113781988946396009556
 tree dripper: https://automation.chain.link/mainnet/16015974269903908984725510916384725148630916297368865448620388766630414318319
@@ -13,7 +13,7 @@ members = {
     "RemBadgerDripper2023": 98030557125143332209375009711552185081207413079136145061022651896587613727137,
     "TreeDripper2023": 16015974269903908984725510916384725148630916297368865448620388766630414318319,
     "TreasuryVoterModule": 42960818007215227498102337773007812241122867237937589685113781988946396009556,
-    # TODO: "GasStationExact": 0 Belongs to old registry, should we cancel it in old registry and register it in the new?
+    "GasStationExact": 89,
 }
 
 


### PR DESCRIPTION
Tackles 2 points from #1133 

For simulating the whole stack of txs:

```
 brownie run issue/1133/upkeep_manager_integration sim
```

Commands to init the manager and test a complete cycle of addition of a dummy dripper, cancellation and see keeper wd the funds once they are avail:

```
brownie run issue/1133/upkeep_manager_integration initial_setup_and_testing

brownie run issue/1133/upkeep_manager_integration cancel_dummy_member
```

Final flow for the config is cancelling existing upkeeps and register them in the upkeep manager by:

```
brownie run issue/1133/upkeep_manager_integration cancel_upkeeps

brownie run issue/1133/upkeep_manager_integration register_members_in_manager
```

~While doing the script I realised that the gas st is registed in the old cl registry, and the upkeep manager was meant to use the latest, what do you guys think if in this script i add also the cancellation of the gas st in the old register and register it in the new one, so we can smoothly add all the members in the manager?~

It require migration for all the upkeeps to the manager, since it checks on the cancelation if the `msg.sender` is the owner of the upkeep id