### PR TITLE
feat: add two approach for wd: softer and max-out

### DIFF
--- a/interfaces/euler/IDebtToken.sol
+++ b/interfaces/euler/IDebtToken.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+/// @notice Tokenised representation of debts
+interface IDebtToken {
+    /// @notice Debt token name, ie "Euler Debt: DAI"
+    function name() external view returns (string memory);
+
+    /// @notice Debt token symbol, ie "dDAI"
+    function symbol() external view returns (string memory);
+
+    /// @notice Decimals of underlying
+    function decimals() external view returns (uint8);
+
+    /// @notice Address of underlying asset
+    function underlyingAsset() external view returns (address);
+
+    /// @notice Sum of all outstanding debts, in underlying units (increases as interest is accrued)
+    function totalSupply() external view returns (uint);
+
+    /// @notice Sum of all outstanding debts, in underlying units normalized to 27 decimals (increases as interest is accrued)
+    function totalSupplyExact() external view returns (uint);
+
+    /// @notice Debt owed by a particular account, in underlying units
+    function balanceOf(address account) external view returns (uint);
+
+    /// @notice Debt owed by a particular account, in underlying units normalized to 27 decimals
+    function balanceOfExact(address account) external view returns (uint);
+
+    /// @notice Transfer underlying tokens from the Euler pool to the sender, and increase sender's dTokens
+    /// @param subAccountId 0 for primary, 1-255 for a sub-account
+    /// @param amount In underlying units (use max uint256 for all available tokens)
+    function borrow(uint subAccountId, uint amount) external;
+
+    /// @notice Transfer underlying tokens from the sender to the Euler pool, and decrease sender's dTokens
+    /// @param subAccountId 0 for primary, 1-255 for a sub-account
+    /// @param amount In underlying units (use max uint256 for full debt owed)
+    function repay(uint subAccountId, uint amount) external;
+
+    /// @notice Request a flash-loan. A onFlashLoan() callback in msg.sender will be invoked, which must repay the loan to the main Euler address prior to returning.
+    /// @param amount In underlying units
+    /// @param data Passed through to the onFlashLoan() callback, so contracts don't need to store transient data in storage
+    function flashLoan(uint amount, bytes calldata data) external;
+
+    /// @notice Allow spender to send an amount of dTokens to a particular sub-account
+    /// @param subAccountId 0 for primary, 1-255 for a sub-account
+    /// @param spender Trusted address
+    /// @param amount In underlying units (use max uint256 for "infinite" allowance)
+    function approveDebt(uint subAccountId, address spender, uint amount) external returns (bool);
+
+    /// @notice Retrieve the current debt allowance
+    /// @param holder Xor with the desired sub-account ID (if applicable)
+    /// @param spender Trusted address
+    function debtAllowance(address holder, address spender) external view returns (uint);
+
+    /// @notice Transfer dTokens to another address (from sub-account 0)
+    /// @param to Xor with the desired sub-account ID (if applicable)
+    /// @param amount In underlying units. Use max uint256 for full balance.
+    function transfer(address to, uint amount) external returns (bool);
+
+    /// @notice Transfer dTokens from one address to another
+    /// @param from Xor with the desired sub-account ID (if applicable)
+    /// @param to This address must've approved the from address, or be a sub-account of msg.sender
+    /// @param amount In underlying units. Use max uint256 for full balance.
+    function transferFrom(address from, address to, uint amount) external returns (bool);
+}

--- a/scripts/warroom/treasury_divest/euler.py
+++ b/scripts/warroom/treasury_divest/euler.py
@@ -3,8 +3,11 @@ from brownie import interface
 from great_ape_safe import GreatApeSafe
 from helpers.addresses import r
 
+# flag
+max_out_wd = False
+
 # NOTE: amount avail may differ from posting till exec
-EXEC_SLIPPAGE = 0.98
+EXEC_SLIPPAGE = 0.95
 
 
 def main():
@@ -14,11 +17,33 @@ def main():
 
     badger = vault.contract(r.treasury_tokens.BADGER)
     ebadger = interface.IEToken(vault.euler.markets.underlyingToEToken(badger))
+    dbadger = interface.IDebtToken(vault.euler.markets.underlyingToDToken(badger))
 
     vault.take_snapshot(tokens=[badger, ebadger])
 
+    ebadger_total_supply = ebadger.totalSupply()
+    ebadger_vault_balance = ebadger.balanceOf(vault)
+
     badger_total_bal_market = badger.balanceOf(vault.euler.euler)
-    badger_wd_amt = badger_total_bal_market * EXEC_SLIPPAGE
+
+    utilisation_rate = dbadger.totalSupply() / ebadger_total_supply
+    market_ownership_rate = ebadger_vault_balance / ebadger_total_supply
+
+    print(
+        f"Market utilisation: {utilisation_rate:2%}. Market ownership: {market_ownership_rate:.2%}"
+    )
+
+    if max_out_wd:
+        # NOTE: this represents a max out of whichever amount is idle in the market to wd
+        # https://etherscan.io/token/0x3472A5A71965499acd81997a54BBA8D852C6E53d?a=0x27182842E098f60e3D576794A5bFFb0777E025d3
+        badger_wd_amt = min(
+            badger_total_bal_market * EXEC_SLIPPAGE, ebadger_vault_balance
+        )
+    else:
+        # NOTE: this represents a softer wd approach consider our percetange of market ownership and utilisation rate
+        badger_wd_amt = (
+            ebadger_total_supply * (1 - utilisation_rate) * (1 - market_ownership_rate)
+        )
 
     vault.euler.withdraw(badger, badger_wd_amt)
 

--- a/scripts/warroom/treasury_divest/euler.py
+++ b/scripts/warroom/treasury_divest/euler.py
@@ -3,12 +3,6 @@ from brownie import interface
 from great_ape_safe import GreatApeSafe
 from helpers.addresses import r
 
-# flag
-max_out_wd = False
-
-# NOTE: amount avail may differ from posting till exec
-EXEC_SLIPPAGE = 0.95
-
 
 def main():
     vault = GreatApeSafe(r.badger_wallets.treasury_vault_multisig)
@@ -29,21 +23,13 @@ def main():
     utilisation_rate = dbadger.totalSupply() / ebadger_total_supply
     market_ownership_rate = ebadger_vault_balance / ebadger_total_supply
 
+    # NOTE: general market info to be aware in the cli prompt in emerg. situation
     print(
         f"Market utilisation: {utilisation_rate:2%}. Market ownership: {market_ownership_rate:.2%}"
     )
 
-    if max_out_wd:
-        # NOTE: this represents a max out of whichever amount is idle in the market to wd
-        # https://etherscan.io/token/0x3472A5A71965499acd81997a54BBA8D852C6E53d?a=0x27182842E098f60e3D576794A5bFFb0777E025d3
-        badger_wd_amt = min(
-            badger_total_bal_market * EXEC_SLIPPAGE, ebadger_vault_balance
-        )
-    else:
-        # NOTE: this represents a softer wd approach consider our percetange of market ownership and utilisation rate
-        badger_wd_amt = (
-            ebadger_total_supply * (1 - utilisation_rate) * (1 - market_ownership_rate)
-        )
+    # https://etherscan.io/token/0x3472A5A71965499acd81997a54BBA8D852C6E53d?a=0x27182842E098f60e3D576794A5bFFb0777E025d3
+    badger_wd_amt = min(badger_total_bal_market, ebadger_vault_balance)
 
     vault.euler.withdraw(badger, badger_wd_amt)
 


### PR DESCRIPTION
Tackles #1189 

~The pr tries to tackle imo two different types of withdrawals that we can have, the softer considering ownership and utilisation ratios and the max-out approach, which solely cares about what is available in the market as idle capital and check the minimum between our total “ebalance” and the available amount.~

~Somehow, made me realised that even at the time of emerg, we kind of tackle the best outcome scenario for us, only it could get reverted if other depositors tried to wd at the same time interval between [t_tx_posting, t_tx_exec] and its more than the `EXEC_SLIPPAGE` reduction.~

Let me know if you think there is a neater approach or I am missing some caveat. read comments below

--------

Uses the approach of the min amount between the max avail amount in the market and the max user balance