### PR TITLE
feat: integrate fee collector module

### DIFF
--- a/great_ape_safe/ape_api/badger.py
+++ b/great_ape_safe/ape_api/badger.py
@@ -424,8 +424,8 @@ class Badger:
             if "executor" in label:
                 min_bal = 1e18
             if label == "upkeep_manager":
-                min_bal = 3e18
-                min_top_up = 2e18
+                min_bal = 5e18
+                min_top_up = 4e18
             if label == "ops_botsquad":
                 min_bal = 5e18
             if label == "ops_deployer":

--- a/great_ape_safe/ape_api/badger.py
+++ b/great_ape_safe/ape_api/badger.py
@@ -424,7 +424,8 @@ class Badger:
             if "executor" in label:
                 min_bal = 1e18
             if label == "upkeep_manager":
-                min_bal = 1e18
+                min_bal = 3e18
+                min_top_up = 2e18
             if label == "ops_botsquad":
                 min_bal = 5e18
             if label == "ops_deployer":

--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -42,6 +42,9 @@ ADDRESSES_ETH = {
         "treasury_vault": {
             "univ3_harvester": "0xF6fA1F20CCD69aD3B7B3a0b8743e6a213521b2E5",
         },
+        "treasury_ops_multisig": {
+            "fee_collector": "0x24a6108D1985B44130f68550C9c43d556720CF17",
+        },
     },
     "cvx_bribes_processor": "0xb2Bf1d48F2C2132913278672e6924efda3385de2",
     "aura_bribes_processor": "0x8ABD28E4D69bD3953b96dd9ED63533765AdB9965",

--- a/scripts/issue/1198/fee_module_integration.py
+++ b/scripts/issue/1198/fee_module_integration.py
@@ -1,0 +1,57 @@
+from brownie import interface
+
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import r
+
+
+def enable_module():
+    trops = GreatApeSafe(r.badger_wallets.treasury_ops_multisig)
+
+    # contracts
+    module = trops.contract(r.safe_modules.treasury_ops_multisig.fee_collector)
+    safe = interface.IGnosisSafe_v1_3_0(
+        r.badger_wallets.treasury_ops_multisig, owner=trops.account
+    )
+
+    # add `feeToken` balancer/aura vaults
+    aura_vaults = [
+        trops.contract(r.sett_vaults.b40WBTC_40DIGG_20graviAURA),
+        trops.contract(r.sett_vaults.b80BADGER_20WBTC),
+    ]
+    for vault in aura_vaults:
+        token = trops.contract(vault.token())
+        pool_id = token.getPoolId()
+        # https://etherscan.io/address/0x24a6108D1985B44130f68550C9c43d556720CF17#code#F1#L121
+        module.addFeeTokenBalancer(vault, True, pool_id)
+
+    # add `feeToken` curve lps
+    curve_lps = [
+        trops.contract(r.treasury_tokens.badgerWBTC_f),
+        trops.contract(r.treasury_tokens.bveCVX_CVX_f),
+    ]
+    for lp in curve_lps:
+        # NOTE: one of the lp, its the pool itself
+        pool_addr = (
+            lp.address if "add_liquidity" in lp.selectors.values() else lp.minter()
+        )
+        # https://etherscan.io/address/0x24a6108D1985B44130f68550C9c43d556720CF17#code#F1#L102
+        module.addFeeTokenCurve(lp, False, pool_addr)
+
+    safe.enableModule(module)
+
+    trops.post_safe_tx()
+
+
+def add_member():
+    techops = GreatApeSafe(r.badger_wallets.techops_multisig)
+    upkeep_manager = techops.contract(r.badger_wallets.upkeep_manager)
+
+    upkeep_manager.addMember(
+        r.safe_modules.treasury_ops_multisig.fee_collector,
+        "FeeCollectorModule",
+        # gas figure ref: https://github.com/Badger-Finance/badger-multisig/issues/1198#issuecomment-1485062644
+        2_000_000,
+        0,
+    )
+
+    techops.post_safe_tx()

--- a/scripts/issue/1198/fee_module_integration.py
+++ b/scripts/issue/1198/fee_module_integration.py
@@ -44,6 +44,7 @@ def enable_module():
 
 def add_member():
     techops = GreatApeSafe(r.badger_wallets.techops_multisig)
+    techops.init_badger()
     upkeep_manager = techops.contract(r.badger_wallets.upkeep_manager)
 
     upkeep_manager.addMember(
@@ -53,5 +54,8 @@ def add_member():
         2_000_000,
         0,
     )
+
+    # NOTE: tackles increasing thresholds in gas st for mngr.
+    techops.badger.set_gas_station_watchlist()
 
     techops.post_safe_tx()


### PR DESCRIPTION
Tackles #1198 

```
brownie run scripts/issue/1198/fee_module_integration enable_module

brownie run scripts/issue/1198/fee_module_integration add_member
```

I think that given the 2m in gas limit for this upkeep id, it may revert when adding the member, since it will require more eth funds. since already at 1m it will require ~121 link 