### PR TITLE
feat: sell arbitrary token stuck in processor

### DIFF
--- a/great_ape_safe/ape_api/cow.py
+++ b/great_ape_safe/ape_api/cow.py
@@ -2,9 +2,9 @@ import json
 import os
 import requests
 from decimal import Decimal
-from pprint import pprint
 
-from brownie import Contract, chain, interface, web3
+from brownie import Contract, chain, interface
+from rich.pretty import pprint
 from rich.prompt import Confirm
 
 from great_ape_safe.ape_api.helpers.coingecko import get_cg_price
@@ -55,7 +55,7 @@ class Cow:
 
         r = requests.post(self.api_url + "quote", json=fee_and_quote_payload)
         print("FEE AND QUOTE RESPONSE:")
-        print(r.json())
+        pprint(r.json())
         print("")
 
         r.raise_for_status()

--- a/great_ape_safe/ape_api/cow.py
+++ b/great_ape_safe/ape_api/cow.py
@@ -54,12 +54,11 @@ class Cow:
         print("")
 
         r = requests.post(self.api_url + "quote", json=fee_and_quote_payload)
-        if not r.ok:
-            r.raise_for_status()
-
         print("FEE AND QUOTE RESPONSE:")
-        pprint(r.json())
+        print(r.json())
         print("")
+
+        r.raise_for_status()
 
         return r.json()
 
@@ -200,13 +199,12 @@ class Cow:
 
         if self.prod:
             r = requests.post(self.api_url + "orders", json=order_payload)
-            if not r.ok:
-                r.raise_for_status()
-
             order_uid = r.json()
             print("ORDER RESPONSE")
             pprint(order_uid)
             print("")
+
+            r.raise_for_status()
 
             # dump order to json and add staging label if necessary
             path = "logs/trading/prod/"

--- a/scripts/badger/process_bribes_graviaura.py
+++ b/scripts/badger/process_bribes_graviaura.py
@@ -4,7 +4,7 @@ from great_ape_safe import GreatApeSafe
 from helpers.addresses import r
 
 # only set to true when actually ready to post and exec on mainnet
-COW_PROD = True
+COW_PROD = False
 
 # artificially create slippage on the quoted price from cowswap
 COEF = 0.98

--- a/scripts/badger/process_bribes_graviaura.py
+++ b/scripts/badger/process_bribes_graviaura.py
@@ -1,5 +1,6 @@
 from brownie import Contract, interface, web3
 from pycoingecko import CoinGeckoAPI
+
 from great_ape_safe import GreatApeSafe
 from helpers.addresses import r
 

--- a/scripts/badger/process_bribes_graviaura.py
+++ b/scripts/badger/process_bribes_graviaura.py
@@ -172,30 +172,28 @@ def sell_weth():
     SAFE.post_safe_tx()
 
 
-def buy_aura(usdc_mantissa):
-    usdc_mantissa = int(usdc_mantissa)
+def buy_aura_or_badger(erc20_addr, mantissa=None, badger=False):
+    erc20_to_sell = VAULT.contract(erc20_addr)
+    if badger:
+        erc20_to_buy = VAULT.contract(r.treasury_tokens.BADGER)
+    else:
+        erc20_to_buy = VAULT.contract(r.treasury_tokens.AURA)
 
-    USDC = interface.ERC20(r.treasury_tokens.USDC, owner=VAULT.account)
-    BADGER = interface.ERC20(r.treasury_tokens.BADGER, owner=VAULT.account)
-    AURA = interface.ERC20(r.treasury_tokens.AURA, owner=VAULT.account)
-    GRAVI_AURA = interface.ITheVault(r.sett_vaults.graviAURA, owner=VAULT.account)
-
-    proc = GreatApeSafe(PROCESSOR.address)
-    proc.take_snapshot([USDC, BADGER, AURA, GRAVI_AURA])
+    if mantissa:
+        mantissa = int(mantissa)
+    else:
+        mantissa = erc20_to_sell.balanceOf(PROCESSOR)
 
     VAULT.init_cow(prod=COW_PROD)
-    VAULT.cow.allow_relayer(USDC, usdc_mantissa)
+    VAULT.cow.allow_relayer(erc20_to_sell, mantissa)
     VAULT.cow.market_sell(
-        USDC,
-        AURA,
-        usdc_mantissa,
+        erc20_to_sell,
+        erc20_to_buy,
+        mantissa,
         deadline=DEADLINE,
         coef=COEF,
         destination=PROCESSOR.address,
     )
-
-    proc.print_snapshot()
-
     VAULT.post_safe_tx()
 
 


### PR DESCRIPTION
this week the weth to aura swap expired. using `buy_aura_or_badger` we can now fix such situations, by passing any erc20 address (weth in this case)

also made a slight change in `cow.py` so that we can actually read api's error response before raising (the requests' response content contains more info that the raise):
```
FEE AND QUOTE PAYLOAD:
{'buyToken': '0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF',
 'from': '0xD0A7A8B98957b9CD3cFB9c0425AbE44551158e9e',
 'kind': 'sell',
 'sellAmountBeforeFee': '3023728579871303680',
 'sellToken': '0xba100000625a3754423978a60c9317c58a424e3D'}

FEE AND QUOTE RESPONSE:
{'errorType': 'SellAmountDoesNotCoverFee', 'description': 'The sell amount for the sell order is lower than the fee.', 'data': {'fee_amount': '0x4f0dbc3ae0b47c00'}}
```