### PR TITLE
feat: avatar ownership transfer, prep for aura pid migrations and remaining funds into avatars

### DIFF
--- a/scripts/avatars/migrate_pids.py
+++ b/scripts/avatars/migrate_pids.py
@@ -31,6 +31,13 @@ def main(aura_migration=True, convex_migration=True, treasury_wd=True):
     # boosters
     aura_booster = vault.contract(r.aura.booster)
 
+    # aura rewards contracts
+    rewards_aura_20wbtc80badger_gauge = vault.contract(r.aura.aura_20wbtc80badger_gauge)
+    rewards_aura_40wbtc40digg20gravi_gauge = vault.contract(
+        r.aura.aura_40wbtc40digg20gravi_gauge
+    )
+    rewards_aura_50reth50badger_gauge = vault.contract(r.aura.aura_50reth50badger_gauge)
+
     # avatars
     aura_avatar = vault.contract(r.avatars.aura)
     convex_avatar = vault.contract(r.avatars.convex)
@@ -53,9 +60,9 @@ def main(aura_migration=True, convex_migration=True, treasury_wd=True):
 
     if treasury_wd:
         # aura wds
-        vault.aura.unstake_all_and_withdraw_all(bpt_badgerwbtc, claim=0)
-        vault.aura.unstake_all_and_withdraw_all(bpt_badgerreth, claim=0)
-        vault.aura.unstake_all_and_withdraw_all(bpt_wbtcdigggravi, claim=0)
+        rewards_aura_20wbtc80badger_gauge.withdrawAllAndUnwrap(0)
+        rewards_aura_40wbtc40digg20gravi_gauge.withdrawAllAndUnwrap(0)
+        rewards_aura_50reth50badger_gauge.withdrawAllAndUnwrap(0)
 
         # convex private wds
         staking_contract = vault.contract(private_vault.stakingAddress())

--- a/scripts/avatars/migrate_pids.py
+++ b/scripts/avatars/migrate_pids.py
@@ -1,0 +1,109 @@
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import r
+
+# Here are exceptions that may exist during migration
+PID_AURA_EXCEPTION = 67
+PID_CONVEX_EXCEPTION = 0
+
+# New pids
+AURA_NEW_PID_WBTC_BADGER = 0  # TBD
+AURA_NEW_PID_WBTC_DIGG_GRAVI = 0  # TBD
+
+
+def sim():
+    # ownership transfer
+    trops = GreatApeSafe(r.badger_wallets.treasury_ops_multisig)
+
+    # avatars
+    aura_avatar = trops.contract(r.avatars.aura)
+    convex_avatar = trops.contract(r.avatars.convex)
+
+    aura_avatar.transferOwnership(r.badger_wallets.treasury_vault_multisig)
+    convex_avatar.transferOwnership(r.badger_wallets.treasury_vault_multisig)
+
+    main(True, True, True)
+
+
+def main(aura_migration=True, convex_migration=True, treasury_wd=True):
+    vault = GreatApeSafe(r.badger_wallets.treasury_vault_multisig)
+    vault.init_aura()
+
+    # avatars
+    aura_avatar = vault.contract(r.avatars.aura)
+    convex_avatar = vault.contract(r.avatars.convex)
+
+    # balancer bpts
+    bpt_badgerwbtc = vault.contract(r.balancer.B_20_BTC_80_BADGER)
+    bpt_badgerreth = vault.contract(r.balancer.B_50_BADGER_50_RETH)
+    bpt_wbtcdigggravi = vault.contract(r.balancer.bpt_40wbtc_40digg_20graviaura)
+
+    # convex private vault
+    private_vault = vault.contract(r.convex.frax.private_vaults.badger_fraxbp)
+
+    # convex wrap lp
+    wcvx_badger_fraxbp = vault.contract(r.convex.frax.wcvx_badger_fraxbp)
+
+    # snap
+    vault.take_snapshot(
+        tokens=[bpt_badgerwbtc, bpt_badgerreth, bpt_wbtcdigggravi, wcvx_badger_fraxbp]
+    )
+
+    if treasury_wd:
+        # aura wds
+        vault.aura.unstake_all_and_withdraw_all(bpt_badgerwbtc, claim=0)
+        vault.aura.unstake_all_and_withdraw_all(bpt_badgerreth, claim=0)
+        vault.aura.unstake_all_and_withdraw_all(bpt_wbtcdigggravi, claim=0)
+
+        # convex private wds
+        staking_contract = vault.contract(private_vault.stakingAddress())
+        kek_id = staking_contract.lockedStakes(private_vault, 0)[0]
+        private_vault.withdrawLocked(kek_id)
+
+        vault.print_snapshot()
+
+    if aura_migration:
+        total_assets = list(aura_avatar.totalAssets())
+
+        pids = list(aura_avatar.getPids())
+        if PID_AURA_EXCEPTION != 0:
+            exception_pid_idx = pids.index(PID_AURA_EXCEPTION)
+            pids.pop(exception_pid_idx)
+            total_assets.pop(exception_pid_idx)
+
+        aura_avatar.withdraw(pids, total_assets)
+        for pid in pids:
+            aura_avatar.removeBptPositionInfo(pid)
+
+        for new_pid in [AURA_NEW_PID_WBTC_BADGER, AURA_NEW_PID_WBTC_DIGG_GRAVI]:
+            aura_avatar.addBptPositionInfo(new_pid)
+
+        bpt_badgerwbtc_balance = bpt_badgerwbtc.balanceOf(vault)
+        bpt_badgerreth_balance = bpt_badgerreth.balanceOf(vault)
+        bpt_wbtcdigggravi_balance = bpt_wbtcdigggravi.balanceOf(vault)
+
+        bpt_badgerwbtc.approve(aura_avatar, bpt_badgerwbtc_balance)
+        bpt_badgerreth.approve(aura_avatar, bpt_badgerreth_balance)
+        bpt_wbtcdigggravi.approve(aura_avatar, bpt_wbtcdigggravi_balance)
+
+        bpts_balances = [
+            bpt_badgerwbtc_balance,
+            bpt_wbtcdigggravi_balance,
+            bpt_badgerreth_balance,
+        ]
+        pids = [
+            AURA_NEW_PID_WBTC_BADGER,
+            AURA_NEW_PID_WBTC_DIGG_GRAVI,
+            PID_AURA_EXCEPTION,
+        ]
+
+        # aura_avatar.deposit(pids, bpts_balances)
+
+    if convex_migration:
+        staking_lp_balance = wcvx_badger_fraxbp.balanceOf(vault)
+        wcvx_badger_fraxbp.approve(convex_avatar, staking_lp_balance)
+        convex_avatar.depositInPrivateVault(
+            convex_avatar.getPrivateVaultPids()[0], staking_lp_balance, True
+        )
+
+    # NOTE: getting `GS013` when not skipping preview - sim
+    vault.post_safe_tx(skip_preview=True)

--- a/scripts/avatars/transfer_ownership.py
+++ b/scripts/avatars/transfer_ownership.py
@@ -1,0 +1,19 @@
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import r
+
+# current owner
+avatar_owner = GreatApeSafe(r.badger_wallets.treasury_ops_multisig)
+
+# new owner
+new_owner = r.badger_wallets.treasury_vault_multisig
+
+# avatars
+aura_avatar = avatar_owner.contract(r.avatars.aura)
+convex_avatar = avatar_owner.contract(r.avatars.convex)
+
+
+def main():
+    aura_avatar.transferOwnership(new_owner)
+    convex_avatar.transferOwnership(new_owner)
+
+    avatar_owner.post_safe_tx()


### PR DESCRIPTION
Tackles #1298 

Ownership transfer:

```
brownie run scripts/avatars/transfer_ownership 
```

Funds migrations to new pids:

```
brownie run scripts/avatars/migrate_pids

brownie run scripts/avatars/migrate_pids sim
```