### PR TITLE
feat: include snap factor diff from the migration to `gauges.aurafinance.eth` space

### DIFF
--- a/scripts/badger/bribe_ecosystems.py
+++ b/scripts/badger/bribe_ecosystems.py
@@ -22,7 +22,7 @@ query ($proposal_id: String) {
 # `state: "all"` ensures all proposals are included
 QUERY_PROPOSALS = """
 query {
-  proposals(first: 100, where: { space: "aurafinance.eth" , state: "all"}) {
+  proposals(first: 100, where: { space: "gauges.aurafinance.eth" , state: "all"}) {
     id
   }
 }
@@ -34,6 +34,9 @@ AURA_TARGET = "50/50 BADGER/rETH"
 
 # gauge to bribe in convex
 CONVEX_TARGET = "BADGER+FRAXBP (0x13B8…)"
+
+# snapshot differentiator after moving into `gauges.aurafinance.eth` space
+AURA_SNAP_DIFF_FACTOR = 1000000
 
 
 def get_index(proposal_id, target):
@@ -96,7 +99,7 @@ def main(
         proposals = response.json()["data"]["proposals"][::-1]
         for proposal in proposals:
             if aura_proposal_id == proposal["id"]:
-                proposal_index = proposals.index(proposal)
+                proposal_index = proposals.index(proposal) + AURA_SNAP_DIFF_FACTOR
                 break
         prop = web3.solidityKeccak(["uint256", "uint256"], [proposal_index, choice])
 


### PR DESCRIPTION
closes #1280

the factor was provided to us via tg:

<img width="504" alt="Screenshot 2023-06-13 at 13 54 00" src="https://github.com/Badger-Finance/badger-multisig/assets/84875062/166c1764-e8a9-43b9-951a-386a0c8dd2e1">


for testing run against the last [prop](https://gaugevotes.aura.finance/#/proposal/0xef2fc2401e5d3c1dd71488109d21b0aed91b736d9880825d491cfa5fd9c69958) and dd [here](https://api.hiddenhand.finance/proposal/aura)
