### PR TITLE
Vault v1.5 deposits pausing helper

### DIFF
--- a/data/badger/timelock/upgrade_slp_geyser/0xfb73cc5ade077cef35bee6c26c6427057d6f5b212a88d908f3f2d4b5b3ab66c2.json
+++ b/data/badger/timelock/upgrade_slp_geyser/0xfb73cc5ade077cef35bee6c26c6427057d6f5b212a88d908f3f2d4b5b3ab66c2.json
@@ -1,7 +1,0 @@
-{
-    "data": "000000000000000000000000d34c1d3853214bf049b760ef48a580bfa7a9c8a1000000000000000000000000c765f078139bf16953ec9eb4ad45fc43c2910e53",
-    "eta": 1685371536,
-    "eth": 0,
-    "signature": "upgrade(address,address)",
-    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
-}

--- a/data/badger/timelock/upgrade_slp_geyser/0xfb73cc5ade077cef35bee6c26c6427057d6f5b212a88d908f3f2d4b5b3ab66c2.json
+++ b/data/badger/timelock/upgrade_slp_geyser/0xfb73cc5ade077cef35bee6c26c6427057d6f5b212a88d908f3f2d4b5b3ab66c2.json
@@ -1,0 +1,7 @@
+{
+    "data": "000000000000000000000000d34c1d3853214bf049b760ef48a580bfa7a9c8a1000000000000000000000000c765f078139bf16953ec9eb4ad45fc43c2910e53",
+    "eta": 1685371536,
+    "eth": 0,
+    "signature": "upgrade(address,address)",
+    "target": "0x20Dce41Acca85E8222D6861Aa6D23B6C941777bF"
+}

--- a/great_ape_safe/ape_api/badger.py
+++ b/great_ape_safe/ape_api/badger.py
@@ -455,3 +455,12 @@ class Badger:
         guestlist.setTotalDepositCap(cap)
         assert guestlist.totalDepositCap() == cap
         C.print(f"[green]New total cap: {cap}[/green]")
+
+    def pause_deposits(self, vault):
+        vault = interface.ITheVault(
+            vault, owner=self.safe.account
+        )
+        assert vault.pausedDeposit() == False
+        vault.pauseDeposits()
+        assert vault.pausedDeposit()
+        C.print(f"[green]Deposits paused for {vault.name()}[/green]")

--- a/great_ape_safe/ape_api/badger.py
+++ b/great_ape_safe/ape_api/badger.py
@@ -457,9 +457,7 @@ class Badger:
         C.print(f"[green]New total cap: {cap}[/green]")
 
     def pause_deposits(self, vault):
-        vault = interface.ITheVault(
-            vault, owner=self.safe.account
-        )
+        vault = interface.ITheVault(vault, owner=self.safe.account)
         assert vault.pausedDeposit() == False
         vault.pauseDeposits()
         assert vault.pausedDeposit()

--- a/scripts/warroom/pause_deposits.py
+++ b/scripts/warroom/pause_deposits.py
@@ -1,14 +1,17 @@
 from great_ape_safe import GreatApeSafe
 from helpers.addresses import r
 
+# Add the vaults' addresses that you wish to pause deposits on
+VAULTS_ARRAY = []
 
-def main(vault_address):
+def main():
     """
     Pauses deposits on a given Vault V1.5 governed by the Dev Multisig
     """
     dev = GreatApeSafe(r.badger_wallets.dev_multisig)
     dev.init_badger()
 
-    dev.badger.pause_deposits(vault_address)
+    for vault_address in VAULTS_ARRAY:
+        dev.badger.pause_deposits(vault_address)
 
     dev.post_safe_tx()

--- a/scripts/warroom/pause_deposits.py
+++ b/scripts/warroom/pause_deposits.py
@@ -1,0 +1,13 @@
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import r
+
+def main(vault_address):
+    """
+    Pauses deposits on a given Vault V1.5 governed by the Dev Multisig
+    """
+    dev = GreatApeSafe(r.badger_wallets.dev_multisig)
+    dev.init_badger()
+
+    dev.badger.pause_deposits(vault_address)
+
+    dev.post_safe_tx()

--- a/scripts/warroom/pause_deposits.py
+++ b/scripts/warroom/pause_deposits.py
@@ -4,6 +4,7 @@ from helpers.addresses import r
 # Add the vaults' addresses that you wish to pause deposits on
 VAULTS_ARRAY = []
 
+
 def main():
     """
     Pauses deposits on a given Vault V1.5 governed by the Dev Multisig

--- a/scripts/warroom/pause_deposits.py
+++ b/scripts/warroom/pause_deposits.py
@@ -1,6 +1,7 @@
 from great_ape_safe import GreatApeSafe
 from helpers.addresses import r
 
+
 def main(vault_address):
     """
     Pauses deposits on a given Vault V1.5 governed by the Dev Multisig


### PR DESCRIPTION
Simple script to pause deposits on a v1.5 vault from dev Multisig as needed.

Use as:
```
brownie run scripts/warroom/pause_deposits.py main vault_address
```