### PR TITLE
feat: include paladin support for bunni/liquis incentives

### DIFF
--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -690,6 +690,9 @@ ADDRESSES_ETH = {
         "claim_zap": "0xad161b8bEb5bf2Af9cDA30E3988B13F62E70431B",
         "liq_vested_escrow": "0xf97964749b52c55d64E971571E1370b2618B718f",
     },
+    "paladin": {
+        "quest_board_velit": "0x602E94D90F34126f31444D001732a1974378D9FC",
+    },
 }
 
 ADDRESSES_IBBTC = {

--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -691,7 +691,7 @@ ADDRESSES_ETH = {
         "liq_vested_escrow": "0xf97964749b52c55d64E971571E1370b2618B718f",
     },
     "paladin": {
-        "quest_board_velit": "0x602E94D90F34126f31444D001732a1974378D9FC",
+        "quest_board_veliq": "0xcbd27bf506aB5580Ef86Fe6a169449bc24Be471B",
     },
 }
 

--- a/interfaces/paladin/IQuestBoard.sol
+++ b/interfaces/paladin/IQuestBoard.sol
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IQuestBoard {
+    function GAUGE_CONTROLLER() external view returns (address);
+
+    function KILL_DELAY() external view returns (uint256);
+
+    function acceptOwnership() external;
+
+    function addMerkleRoot(
+        uint256 questID,
+        uint256 period,
+        uint256 totalAmount,
+        bytes32 merkleRoot
+    ) external;
+
+    function addMultipleMerkleRoot(
+        uint256[] memory questIDs,
+        uint256 period,
+        uint256[] memory totalAmounts,
+        bytes32[] memory merkleRoots
+    ) external;
+
+    function approveManager(address newManager) external;
+
+    function closePartOfQuestPeriod(uint256 period, uint256[] memory questIDs)
+        external
+        returns (uint256 closed, uint256 skipped);
+
+    function closeQuestPeriod(uint256 period)
+        external
+        returns (uint256 closed, uint256 skipped);
+
+    function createQuest(
+        address gauge,
+        address rewardToken,
+        uint48 duration,
+        uint256 objective,
+        uint256 rewardPerVote,
+        uint256 totalRewardAmount,
+        uint256 feeAmount
+    ) external returns (uint256);
+
+    function distributor() external view returns (address);
+
+    function emergencyWithdraw(uint256 questID, address recipient) external;
+
+    function getAllPeriodsForQuestId(uint256 questId)
+        external
+        view
+        returns (uint48[] memory);
+
+    function getAllQuestPeriodsForQuestId(uint256 questId)
+        external
+        view
+        returns (QuestBoard.QuestPeriod[] memory);
+
+    function getCurrentPeriod() external view returns (uint256);
+
+    function getQuestIdsForPeriod(uint256 period)
+        external
+        view
+        returns (uint256[] memory);
+
+    function increaseQuestDuration(
+        uint256 questID,
+        uint48 addedDuration,
+        uint256 addedRewardAmount,
+        uint256 feeAmount
+    ) external;
+
+    function increaseQuestObjective(
+        uint256 questID,
+        uint256 newObjective,
+        uint256 addedRewardAmount,
+        uint256 feeAmount
+    ) external;
+
+    function increaseQuestReward(
+        uint256 questID,
+        uint256 newRewardPerVote,
+        uint256 addedRewardAmount,
+        uint256 feeAmount
+    ) external;
+
+    function initiateDistributor(address newDistributor) external;
+
+    function isKilled() external view returns (bool);
+
+    function killBoard() external;
+
+    function kill_ts() external view returns (uint256);
+
+    function minObjective() external view returns (uint256);
+
+    function minRewardPerVotePerToken(address) external view returns (uint256);
+
+    function nextID() external view returns (uint256);
+
+    function owner() external view returns (address);
+
+    function pendingOwner() external view returns (address);
+
+    function periodsByQuest(uint256, uint256)
+        external
+        view
+        returns (
+            uint256 rewardAmountPerPeriod,
+            uint256 rewardPerVote,
+            uint256 objectiveVotes,
+            uint256 rewardAmountDistributed,
+            uint256 withdrawableAmount,
+            uint48 periodStart,
+            uint8 currentState
+        );
+
+    function platformFee() external view returns (uint256);
+
+    function questChest() external view returns (address);
+
+    function questDistributors(uint256) external view returns (address);
+
+    function questPeriods(uint256, uint256) external view returns (uint48);
+
+    function quests(uint256)
+        external
+        view
+        returns (
+            address creator,
+            address rewardToken,
+            address gauge,
+            uint48 duration,
+            uint48 periodStart,
+            uint256 totalRewardAmount
+        );
+
+    function questsByPeriod(uint256, uint256) external view returns (uint256);
+
+    function recoverERC20(address token) external returns (bool);
+
+    function removeManager(address manager) external;
+
+    function renounceOwnership() external;
+
+    function transferOwnership(address newOwner) external;
+
+    function unkillBoard() external;
+
+    function updateChest(address chest) external;
+
+    function updateDistributor(address newDistributor) external;
+
+    function updateMinObjective(uint256 newMinObjective) external;
+
+    function updatePlatformFee(uint256 newFee) external;
+
+    function updateRewardToken(address newToken, uint256 newMinRewardPerVote)
+        external;
+
+    function whitelistMultipleTokens(
+        address[] memory newTokens,
+        uint256[] memory minRewardPerVotes
+    ) external;
+
+    function whitelistToken(address newToken, uint256 minRewardPerVote)
+        external;
+
+    function whitelistedTokens(address) external view returns (bool);
+
+    function withdrawUnusedRewards(uint256 questID, address recipient) external;
+}
+
+interface QuestBoard {
+    struct QuestPeriod {
+        uint256 rewardAmountPerPeriod;
+        uint256 rewardPerVote;
+        uint256 objectiveVotes;
+        uint256 rewardAmountDistributed;
+        uint256 withdrawableAmount;
+        uint48 periodStart;
+        uint8 currentState;
+    }
+}

--- a/scripts/badger/bribe_ecosystems.py
+++ b/scripts/badger/bribe_ecosystems.py
@@ -220,26 +220,26 @@ def main(
 
         mantissa = int(bribes["liquis"] / badger_rate * Decimal(1e18))
 
-        platform_fee = (mantissa * palading_quest_board_veliq.platformFee()) / MAX_BPS
+        platform_fee = int((Decimal(mantissa) * palading_quest_board_veliq.platformFee()) / MAX_BPS)
 
         min_reward_per_vote = palading_quest_board_veliq.minRewardPerVotePerToken(
             badger
         )
 
-        objective = mantissa / reward_per_vote_liquis
-        reward_per_vote_liquis = Decimal(reward_per_vote_liquis) * Decimal(1e18)
+        reward_per_vote_liquis = reward_per_vote_liquis * 1e18
+        objective = (Decimal(mantissa) * Decimal(1e18)) / Decimal(reward_per_vote_liquis)
 
         assert reward_per_vote_liquis > min_reward_per_vote
         assert objective > palading_quest_board_veliq.minObjective()
         assert duration_paladin_quest >= 1
 
-        badger.approve(palading_quest_board_veliq, mantissa)
+        badger.approve(palading_quest_board_veliq, mantissa + platform_fee)
         palading_quest_board_veliq.createQuest(
             r.bunni.badger_wbtc_bunni_gauge_309720_332580,  # address gauge
             badger.address,  # address rewardToken
             duration_paladin_quest,  # uint48 duration
             objective,  # uint256 objective
-            min_reward_per_vote,  # uint256 rewardPerVote
+            reward_per_vote_liquis,  # uint256 rewardPerVote
             mantissa,  # uint256 totalRewardAmount
             platform_fee,  # uint256 feeAmount
         )

--- a/scripts/badger/bribe_ecosystems.py
+++ b/scripts/badger/bribe_ecosystems.py
@@ -97,8 +97,8 @@ def main(
     frax_briber = safe.contract(r.hidden_hand.frax_briber, interface.IBribeMarket)
     bunni_briber = safe.contract(r.hidden_hand.bunni_briber, interface.IBribeMarket)
 
-    palading_quest_board_velit = safe.contract(
-        r.paladin.quest_board_velit, interface.IQuestBoard
+    palading_quest_board_veliq = safe.contract(
+        r.paladin.quest_board_veliq, interface.IQuestBoard
     )
 
     if bribes["aura"] > 0:
@@ -220,9 +220,9 @@ def main(
 
         mantissa = int(bribes["liquis"] / badger_rate * Decimal(1e18))
 
-        platform_fee = (mantissa * palading_quest_board_velit.platformFee()) / MAX_BPS
+        platform_fee = (mantissa * palading_quest_board_veliq.platformFee()) / MAX_BPS
 
-        min_reward_per_vote = palading_quest_board_velit.minRewardPerVotePerToken(
+        min_reward_per_vote = palading_quest_board_veliq.minRewardPerVotePerToken(
             badger
         )
 
@@ -230,11 +230,11 @@ def main(
         reward_per_vote_liquis = Decimal(reward_per_vote_liquis) * Decimal(1e18)
 
         assert reward_per_vote_liquis > min_reward_per_vote
-        assert objective > palading_quest_board_velit.minObjective()
+        assert objective > palading_quest_board_veliq.minObjective()
         assert duration_paladin_quest >= 1
 
-        badger.approve(palading_quest_board_velit, mantissa)
-        palading_quest_board_velit.createQuest(
+        badger.approve(palading_quest_board_veliq, mantissa)
+        palading_quest_board_veliq.createQuest(
             r.bunni.badger_wbtc_bunni_gauge_309720_332580,  # address gauge
             badger.address,  # address rewardToken
             duration_paladin_quest,  # uint48 duration

--- a/scripts/badger/bribe_ecosystems.py
+++ b/scripts/badger/bribe_ecosystems.py
@@ -63,7 +63,7 @@ def main(
     badger_bribe_in_bunni=0,  # NOTE: dollar denominated. Badger calculation is done internaly
     max_tokens_per_vote=0,  # Maximum amount of incentives to be used per round (Hidden Hands V2)
     periods=1,  # Rounds to be covered by the incentives deposited (Hidden Hands V2)
-    badger_bribe_in_liquis=0,  # NOTE: the incentive gets process via Paladin
+    badger_bribe_in_liquis=0,  # NOTE: dollar denominated. Badger calculation is done internaly, the incentive gets process via Paladin
     duration_paladin_quest=1,  # Duration (in number of periods) of the Quest
     reward_per_vote_liquis=0,  # Amount of reward per vlLIQ
     aura_proposal_id=None,

--- a/scripts/badger/bribe_ecosystems.py
+++ b/scripts/badger/bribe_ecosystems.py
@@ -220,14 +220,18 @@ def main(
 
         mantissa = int(bribes["liquis"] / badger_rate * Decimal(1e18))
 
-        platform_fee = int((Decimal(mantissa) * palading_quest_board_veliq.platformFee()) / MAX_BPS)
+        platform_fee = int(
+            (Decimal(mantissa) * palading_quest_board_veliq.platformFee()) / MAX_BPS
+        )
 
         min_reward_per_vote = palading_quest_board_veliq.minRewardPerVotePerToken(
             badger
         )
 
         reward_per_vote_liquis = reward_per_vote_liquis * 1e18
-        objective = (Decimal(mantissa) * Decimal(1e18)) / Decimal(reward_per_vote_liquis)
+        objective = (Decimal(mantissa) * Decimal(1e18)) / Decimal(
+            reward_per_vote_liquis
+        )
 
         assert reward_per_vote_liquis > min_reward_per_vote
         assert objective > palading_quest_board_veliq.minObjective()

--- a/scripts/badger/bribe_ecosystems.py
+++ b/scripts/badger/bribe_ecosystems.py
@@ -65,7 +65,7 @@ def main(
     periods=1,  # Rounds to be covered by the incentives deposited (Hidden Hands V2)
     badger_bribe_in_liquis=0,  # NOTE: the incentive gets process via Paladin
     duration_paladin_quest=1,  # Duration (in number of periods) of the Quest
-    reward_per_vote_liquis=0,  # Amount of reward per veLIT/vlLIQ (in wei)
+    reward_per_vote_liquis=0,  # Amount of reward per vlLIQ
     aura_proposal_id=None,
     convex_proposal_id=None,
 ):

--- a/scripts/badger/bribe_ecosystems.py
+++ b/scripts/badger/bribe_ecosystems.py
@@ -38,6 +38,8 @@ CONVEX_TARGET = "BADGER+FRAXBP (0x13B8…)"
 # snapshot differentiator after moving into `gauges.aurafinance.eth` space
 AURA_SNAP_DIFF_FACTOR = 1000000
 
+MAX_BPS = 10_000
+
 
 def get_index(proposal_id, target):
     # grab data from the snapshot endpoint re proposal choices
@@ -61,6 +63,9 @@ def main(
     badger_bribe_in_bunni=0,  # NOTE: dollar denominated. Badger calculation is done internaly
     max_tokens_per_vote=0,  # Maximum amount of incentives to be used per round (Hidden Hands V2)
     periods=1,  # Rounds to be covered by the incentives deposited (Hidden Hands V2)
+    badger_bribe_in_liquis=0,  # NOTE: the incentive gets process via Paladin
+    duration_paladin_quest=1,  # Duration (in number of periods) of the Quest
+    reward_per_vote_liquis=0,  # Amount of reward per veLIT/vlLIQ (in wei)
     aura_proposal_id=None,
     convex_proposal_id=None,
 ):
@@ -70,6 +75,7 @@ def main(
         "votium": badger_bribe_in_votium,
         "frax": badger_bribe_in_frax,
         "bunni": badger_bribe_in_bunni,
+        "liquis": badger_bribe_in_liquis,
     }
     for k, v in bribes.items():
         try:
@@ -90,6 +96,10 @@ def main(
     votium_briber = safe.contract(r.votium.bribe, interface.IVotiumBribe)
     frax_briber = safe.contract(r.hidden_hand.frax_briber, interface.IBribeMarket)
     bunni_briber = safe.contract(r.hidden_hand.bunni_briber, interface.IBribeMarket)
+
+    palading_quest_board_velit = safe.contract(
+        r.paladin.quest_board_velit, interface.IQuestBoard
+    )
 
     if bribes["aura"] > 0:
         assert aura_proposal_id
@@ -152,7 +162,7 @@ def main(
             )
     elif bribes["balancer"] > 0:
         bribe_balancer(
-            r.balancer.B_20_BTC_80_BADGER_GAUGE, bribes["balancer"] * Decimal(1e18)
+            r.balancer.B_50_BADGER_50_RETH_GAUGE, bribes["balancer"] * Decimal(1e18)
         )
 
     if bribes["votium"] > 0:
@@ -185,7 +195,9 @@ def main(
             cg.get_price(ids="badger-dao", vs_currencies="usd")["badger-dao"]["usd"]
         )
 
-        prop = web3.solidityKeccak(["address"], [r.bunni.badger_wbtc_bunni_gauge])
+        prop = web3.solidityKeccak(
+            ["address"], [r.bunni.badger_wbtc_bunni_gauge_309720_332580]
+        )
         print("prop", prop.hex())
         mantissa = int(bribes["bunni"] / badger_rate * Decimal(1e18))
 
@@ -196,6 +208,40 @@ def main(
             mantissa,  # uint256 amount
             max_tokens_per_vote,  # uint256 _maxTokensPerVote,
             periods,  #  uint256 _periods
+        )
+
+    if bribes["liquis"] > 0:
+        # NOTE: Treasury decision is expressed in dollars
+        # ref: https://forum.badger.finance/t/34-liquis-partner-engagement/6029
+        cg = CoinGeckoAPI(os.getenv("COINGECKO_API_KEY"))
+        badger_rate = Decimal(
+            cg.get_price(ids="badger-dao", vs_currencies="usd")["badger-dao"]["usd"]
+        )
+
+        mantissa = int(bribes["liquis"] / badger_rate * Decimal(1e18))
+
+        platform_fee = (mantissa * palading_quest_board_velit.platformFee()) / MAX_BPS
+
+        min_reward_per_vote = palading_quest_board_velit.minRewardPerVotePerToken(
+            badger
+        )
+
+        objective = mantissa / reward_per_vote_liquis
+        reward_per_vote_liquis = Decimal(reward_per_vote_liquis) * Decimal(1e18)
+
+        assert reward_per_vote_liquis > min_reward_per_vote
+        assert objective > palading_quest_board_velit.minObjective()
+        assert duration_paladin_quest >= 1
+
+        badger.approve(palading_quest_board_velit, mantissa)
+        palading_quest_board_velit.createQuest(
+            r.bunni.badger_wbtc_bunni_gauge_309720_332580,  # address gauge
+            badger.address,  # address rewardToken
+            duration_paladin_quest,  # uint48 duration
+            objective,  # uint256 objective
+            min_reward_per_vote,  # uint256 rewardPerVote
+            mantissa,  # uint256 totalRewardAmount
+            platform_fee,  # uint256 feeAmount
         )
 
     safe.post_safe_tx()


### PR DESCRIPTION
Tackles #1396 

```
brownie run scripts/badger/bribe_ecosystems
```

Use for testing following params:

```
    ....
    badger_bribe_in_liquis=1000,  # NOTE: the incentive gets process via Paladin
    duration_paladin_quest=1,  # Duration (in number of periods) of the Quest
    reward_per_vote_liquis=0.006,
    ....
```