### PR TITLE
Update AutonomousDripper.sol: Optimized gas costs

### DIFF
--- a/contracts/AutonomousDripper.sol
+++ b/contracts/AutonomousDripper.sol
@@ -64,12 +64,16 @@ contract AutonomousDripper is VestingWallet, KeeperCompatibleInterface, Confirme
      */
     function _getAssetsHeld() internal view returns (address[] memory) {
         address[] memory _assetsHeld = new address[](assetsWatchlist.length);
-        uint256 count = 0;
-        for (uint idx = 0; idx < assetsWatchlist.length; idx++) {
+        uint256 count;
+        for (uint idx; idx < assetsWatchlist.length;) {
             uint256 balance = IERC20(assetsWatchlist[idx]).balanceOf(address(this));
             if (balance > 0) {
                 _assetsHeld[count] = assetsWatchlist[idx];
                 count++;
+            }
+
+            unchecked {
+                ++idx;
             }
         }
         if (count != assetsWatchlist.length) {
@@ -103,11 +107,15 @@ contract AutonomousDripper is VestingWallet, KeeperCompatibleInterface, Confirme
     function performUpkeep(bytes calldata performData) external override onlyKeeperRegistry whenNotPaused {
         if ((block.timestamp - lastTimestamp) > interval) {
             address[] memory assetsHeld = abi.decode(performData, (address[]));
-            bool dripped = false;
-            for (uint idx = 0; idx < assetsHeld.length; idx++) {
+            bool dripped;
+            for (uint idx; idx < assetsHeld.length;) {
                 if (IERC20(assetsHeld[idx]).balanceOf(address(this)) > 0) {
                     VestingWallet.release(assetsHeld[idx]);
                     dripped = true;
+                }
+
+                unchecked {
+                    ++idx;
                 }
             }
             if (dripped) {


### PR DESCRIPTION
This PR aims for two main changes:
1. Optimized `for` loop: Well, the way these 'for' loops were structured in this smart contract were quite normal but kind of taking more gas than it needed to execute. Changing `i++` to `++i`, and using the `unchecked` block alone can play a lot of effect. For more info, refer this -> https://gist.github.com/grGred/9bab8b9bad0cd42fc23d4e31e7347144#for-loops-improvement. This convo might help -> https://github.com/lurk-lab/solidity-verifier/pull/31
2. Changes `uint256 count = 0;` to `uint256 count;`: Usually, default values of unsigned integers are 0 itself, thus there's no need to initialize any unsigned integer to 0. This same change takes effect in case of `bool dripped = false;` to `bool dripped;`