### PR TITLE
feat: allow possibility of using #liq as incentive in liquis marketplace paladin

### DIFF
--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -693,9 +693,13 @@ ADDRESSES_ETH = {
         "claim_zap": "0xad161b8bEb5bf2Af9cDA30E3988B13F62E70431B",
         "liq_vested_escrow": "0xf97964749b52c55d64E971571E1370b2618B718f",
         "rewards_pool_309720_332580": "0xB99ca33d35Ea7B520EC779F001C0C0b971aAb395",
+        "voter_proxy": "0x37aeB332D6E57112f1BFE36923a7ee670Ee9278b",
     },
     "paladin": {
-        "quest_board_veliq": "0xcbd27bf506aB5580Ef86Fe6a169449bc24Be471B",
+        "quest_board_veliq": "0x1B921DBD13A280ee14BA6361c1196EB72aaa094e",
+        "_deprecated": {
+            "quest_board_veliq": "0xcbd27bf506aB5580Ef86Fe6a169449bc24Be471B",
+        },
     },
 }
 

--- a/scripts/badger/bribe_ecosystems.py
+++ b/scripts/badger/bribe_ecosystems.py
@@ -229,7 +229,7 @@ def main(
             liquis_rate = Decimal(
                 cg.get_price(ids="liquis", vs_currencies="usd")["liquis"]["usd"]
             )
-
+        print("liquis_rate", liquis_rate)
         if liquis_incentive_in_paladin:
             rate = badger_rate if is_governance_incentive_token else liquis_rate
             mantissa = int(bribes["liquis"] / rate * Decimal(1e18))
@@ -240,6 +240,8 @@ def main(
             min_reward_per_vote = palading_quest_board_veliq.minRewardPerVotePerToken(
                 badger if is_governance_incentive_token else liquis
             )
+
+            print("min_reward_per_vote", min_reward_per_vote)
 
             reward_per_vote_liquis = reward_per_vote_liquis * 1e18
             objective = (Decimal(mantissa) * Decimal(1e18)) / Decimal(
@@ -253,7 +255,7 @@ def main(
             # approve incentive token conditional based on flag
             if is_governance_incentive_token:
                 badger.approve(palading_quest_board_veliq, mantissa + platform_fee)
-            else: 
+            else:
                 liquis.approve(palading_quest_board_veliq, mantissa + platform_fee)
 
             # create incentive quest


### PR DESCRIPTION
closes #1468 

params for testing:

```
    badger_bribe_in_aura=0,
    badger_bribe_in_balancer=0,
    badger_bribe_in_votium=0,
    badger_bribe_in_frax=0,
    badger_bribe_in_bunni=0,  # NOTE: dollar denominated. Badger calculation is done internaly
    max_tokens_per_vote=0,  # Maximum amount of incentives to be used per round (Hidden Hands V2)
    periods=1,  # Rounds to be covered by the incentives deposited (Hidden Hands V2)
    badger_bribe_in_liquis=2000,  # NOTE: dollar denominated. Badger calculation is done internaly, the incentive gets process via Paladin
    duration_paladin_quest=1,  # Duration (in number of periods) of the Quest
    reward_per_vote_liquis=0.001,  # Amount of reward per vlLIQ
    liquis_incentive_in_paladin=True,  # Indicates if the incentive is going to be post in paladin or HH
    is_governance_incentive_token=False,  # Indicates if the incentive is going to be governance token ($badger) or different. Applicable only in Paladin.
    aura_proposal_id=None,
    convex_proposal_id=None,
```


~~**NOTE**: currently the `minRewardPerVotePerToken` is .0025 and we requested to paladin to decrease it to .001 similar to tokens rates like $grai etc. waiting on that to be fully updated onchain to use this script~~

**NOTE**: got informed by paladin that addys were updated and new contract was in place with min rates updates across the board for tokens, which i verified. script now is on good state using v2 quest sc for velit/vlliq. in our particular case, i had isolated only to incentive vlliq