### PR TITLE
feat: curve incentives script

### DIFF
--- a/helpers/addresses.py
+++ b/helpers/addresses.py
@@ -256,6 +256,8 @@ ADDRESSES_ETH = {
         "LIQ": "0xD82fd4D6D62f89A1E50b1db69AD19932314aa408",
         "LIQLIT": "0x03C6F0Ca0363652398abfb08d154F114e61c4Ad8",
         "LUSD": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+        "STETH": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+        "WSTETH": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
     },
     # every slp token listed in treasury tokens above must also be listed here.
     # the lp_tokens in this list are processed by scount to determine holdings
@@ -306,6 +308,10 @@ ADDRESSES_ETH = {
         "t_eth_f": "0x752eBeb79963cf0732E9c0fec72a49FD1DEfAEAC",
         "cvx_eth_f": "0xB576491F1E6e5E62f1d8F26062Ee822B40B0E0d4",
         "badgerFRAXBP_f": "0x13B876C26Ad6d21cb87AE459EaF6d7A1b788A113",
+        "ebtc_wsteth": "0x94a5B3A7AAF67415B7F5973ed1Adf542897a45F1",
+    },
+    "crv_gauges": {
+        "ebtc_wsteth_gauge": "0xBEb468BEb5C72d8b4d4f076F473Db398562769ed",
     },
     # mStable want tokens
     "mstable_vaults": {

--- a/interfaces/curve/ILiquidityGaugeV6.sol
+++ b/interfaces/curve/ILiquidityGaugeV6.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.7.0;
+
+interface ILiquidityGaugeV6 {
+    function deposit_reward_token(address _reward_token, uint256 _amount, uint256 _epoch) external;
+}

--- a/scripts/curve/lido_gauge_incentives.py
+++ b/scripts/curve/lido_gauge_incentives.py
@@ -1,0 +1,40 @@
+from great_ape_safe import GreatApeSafe
+from helpers.addresses import r
+from brownie import interface
+
+STETH = r.treasury_tokens.STETH
+WSTETH = r.treasury_tokens.WSTETH
+GAUGE = r.crv_gauges.ebtc_wsteth_gauge
+
+TROPS = r.badger_wallets.treasury_ops_multisig
+
+MONTH = 60 * 60 * 24 * 7 * 4 # Epoch
+
+def main(amount=0, epoch=MONTH, use_wsteth=True):
+    """
+    Deposit stETH or wstETH into the eBTC/wstETH Curve gauge for a given epoch
+    
+    Args:
+        amount (int): Decimal amount of stETH or wstETH to deposit
+        epoch (int): Epoch length to deposit the amount, default 1 month
+        use_wsteth (bool): Use wstETH instead of stETH
+    """
+    safe = GreatApeSafe(TROPS)
+    gauge = safe.contract(GAUGE, Interface=interface.ILiquidityGaugeV6)
+    amount = int(float(amount) * 1e18)
+
+    if use_wsteth:
+        token = safe.contract(WSTETH)
+    else:
+        token = safe.contract(STETH)
+
+    # 1. Approve amount
+    token.approve(GAUGE, amount)
+
+    # 2. Deposit amount
+    gauge.deposit_reward_token(token.address, amount, epoch)
+
+    # 3. Confirm deposit
+    print(gauge.reward_data(token))
+
+    safe.post_safe_tx()


### PR DESCRIPTION
Tackles https://github.com/Badger-Finance/badger-multisig/issues/1539

Run with:
```
brownie run scripts/curve/lido_gauge_incentives.py main 4.22
```

Can optionally take a different epoch, defaults to 1 month.

NOTE:
@petrovska-petro @gosuto-inzasheru, I keep getting the following error: 
```
Transaction sent: 0x6da33715a9e064376bc49bb0ddf63d174abb1e18970ecbd49ea62aa40a4ed103
  Gas price: 0.0 gwei   Gas limit: 12000000   Nonce: 16
  ILiquidityGaugeV6.deposit_reward_token confirmed (invalid opcode)   Block: 19962371   Gas used: 12000000 (100.00%)
```

Tested the same transaction via [Tenderly](https://dashboard.tenderly.co/public/safe/safe-apps/simulator/dffc3693-9482-47c5-9637-5d7c8874b52a?trace=0.1.7.0.1), and it worked. I confirmed that the call_data is correct by encoding it through the script and comparing it to Tenderly's (`0x33b50aed0000000000000000000000007f39c581f595b53c5cb19bd0b3f8da6c935e2ca00000000000000000000000000000000000000000000000003a9073a438260000000000000000000000000000000000000000000000000000000000000024ea00`). Attempting to call it normally or by passing the calldata directly returns the same error. I am inclined to believe that this is one of those obscure Brownie issues.

Please let me know if it works from your side.

## Alternative
The following JSON represents a batch of the approval and deposit and can be imported to the Gnosis Safe UI. It could be re-used on a monthly basis and the amount to approve and deposit can be adjusted through the UI. At least while we figure out how to fix the script.

[Lido incentives.json](https://github.com/Badger-Finance/badger-multisig/files/15458973/Lido.incentives.json)
